### PR TITLE
db: SQLite adapter via ArgusDB split + matrix CI over both backends

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -19,24 +19,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  python:
+  # Static checks run once per change. The test matrix below brings up DB
+  # services, so keeping lint separate avoids paying that cost twice.
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        # setup-uv stopped publishing major-version tags (no `@v8`) for supply-chain
-        # reasons — see release notes for v8.0.0. Pin a specific version instead.
-        uses: astral-sh/setup-uv@v8.1.0
+      # setup-uv stopped publishing major-version tags (no `@v8`) for supply-chain
+      # reasons — see release notes for v8.0.0. Pin a specific version instead.
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
           enable-cache: true
 
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Install workspace
-        run: uv sync --all-extras
+      - run: uv python install 3.12
+      - run: uv sync --all-extras
 
       - name: Lint
         run: uv run ruff check packages/server tests/sample-app
@@ -44,5 +42,54 @@ jobs:
       - name: Format check
         run: uv run ruff format --check packages/server tests/sample-app
 
-      - name: Test
+  # Unit + integration tests run once per backend. The integration suite
+  # under packages/server/tests/integration/ runs DBOS migrations against
+  # ARGUS_TEST_DATABASE_URL, seeds a small fixture, and exercises every
+  # `ArgusDB` adapter method. With the URL unset (the `sqlite` matrix dim)
+  # the conftest falls back to a tempfile, so both adapters get the same
+  # battery of tests.
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - db: sqlite
+            test_url: ""
+          - db: postgres
+            test_url: postgresql+asyncpg://argus:argus@localhost:5432/argus
+
+    services:
+      # Always provisioned so the matrix can stay flat. The sqlite leg
+      # ignores it; cost is a few seconds of container startup.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: argus
+          POSTGRES_PASSWORD: argus
+          POSTGRES_DB: argus
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      ARGUS_TEST_DATABASE_URL: ${{ matrix.test_url }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - run: uv python install 3.12
+      - run: uv sync --all-extras
+
+      - name: Test (${{ matrix.db }})
         run: uv run pytest packages/server

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ packages/server/dbos_argus/_console/
 
 # Logs
 *.log
+
+# SQLite test fixtures — sample-app may materialize a local sqlite system DB
+# when DBOS_SYSTEM_DATABASE_URL points at one. Always rebuilt; never tracked.
+*.sqlite
+*.sqlite-journal
+*.sqlite-wal
+*.sqlite-shm

--- a/packages/server/dbos_argus/db.py
+++ b/packages/server/dbos_argus/db.py
@@ -1,6 +1,0 @@
-from sqlalchemy.ext.asyncio import create_async_engine
-
-from .settings import settings
-
-_url, _connect_args = settings.asyncpg_engine_args()
-engine = create_async_engine(_url, echo=False, future=True, connect_args=_connect_args)

--- a/packages/server/dbos_argus/db/__init__.py
+++ b/packages/server/dbos_argus/db/__init__.py
@@ -1,0 +1,31 @@
+"""DBOS database adapter package.
+
+`make_db()` picks an `ArgusDB` implementation from `settings.database_url`.
+`db` is the eagerly-constructed singleton; `engine` is re-exported for the
+small handful of call sites (CLI, schema-bootstrap script) that still use the
+SQLAlchemy engine directly.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.engine.url import make_url
+
+from ..settings import settings
+from .base import ArgusDB
+from .postgres import PostgresArgusDB
+from .sqlite import SqliteArgusDB
+
+
+def make_db() -> ArgusDB:
+    drivername = make_url(settings.database_url).drivername.split("+", 1)[0]
+    if drivername in ("postgresql", "postgres"):
+        return PostgresArgusDB(settings)
+    if drivername == "sqlite":
+        return SqliteArgusDB(settings)
+    raise ValueError(f"Unsupported database driver: {drivername!r}. Supported: postgresql, sqlite.")
+
+
+db: ArgusDB = make_db()
+engine = db.engine
+
+__all__ = ["ArgusDB", "PostgresArgusDB", "SqliteArgusDB", "db", "engine", "make_db"]

--- a/packages/server/dbos_argus/db/base.py
+++ b/packages/server/dbos_argus/db/base.py
@@ -1,0 +1,81 @@
+"""Adapter interface for the DBOS system database.
+
+Argus reads — never writes — DBOS Transact's system tables. Different DBOS
+backends use different SQL dialects (currently Postgres; SQLite coming), so
+endpoints in `main.py` go through this protocol rather than emitting SQL
+directly. Each implementation owns its engine and its own queries.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ..schema_dump import SchemaDump
+from .rows import (
+    NotificationFilters,
+    NotificationsRows,
+    ResultRow,
+    ScheduleRow,
+    StatsRow,
+    ThroughputRow,
+    WorkflowDetailRows,
+    WorkflowFilters,
+    WorkflowListRow,
+)
+
+
+class ArgusDB(ABC):
+    """Per-dialect adapter. Read-only — no method ever writes."""
+
+    engine: AsyncEngine
+
+    @property
+    @abstractmethod
+    def display_url(self) -> str:
+        """Connection URL with credentials redacted, for `/healthz`."""
+
+    @abstractmethod
+    async def healthcheck(self) -> None:
+        """Run a no-op query; raise on failure."""
+
+    @abstractmethod
+    async def reflect_schema(self, schema: str = "dbos") -> SchemaDump:
+        """Return the live DB's schema as a dialect-neutral `SchemaDump`."""
+
+    @abstractmethod
+    async def list_workflows(self, filters: WorkflowFilters) -> list[WorkflowListRow]:
+        """Workflow list page rows, with op counts. Empty when the DBOS
+        schema doesn't exist yet."""
+
+    @abstractmethod
+    async def get_workflow_detail(self, workflow_id: str) -> WorkflowDetailRows:
+        """Whole family tree + steps + events for a single workflow's family.
+        Empty when not found / schema absent — `main.py` raises 404."""
+
+    @abstractmethod
+    async def get_workflow_result(self, workflow_id: str) -> ResultRow | None:
+        """Lazy-loaded output/error payload for one workflow row."""
+
+    @abstractmethod
+    async def get_step_result(self, workflow_id: str, function_id: int) -> ResultRow | None:
+        """Lazy-loaded output/error payload for one operation_outputs row."""
+
+    @abstractmethod
+    async def get_stats(self, since_ms: int) -> StatsRow:
+        """Dashboard rollup. Returns a zeroed `StatsRow` when schema absent."""
+
+    @abstractmethod
+    async def get_throughput(
+        self, since_ms: int, until_ms: int, bucket: Literal["hour", "day"]
+    ) -> list[ThroughputRow]:
+        """Time-bucketed succeeded/errored/running counts."""
+
+    @abstractmethod
+    async def list_schedules(self) -> list[ScheduleRow]: ...
+
+    @abstractmethod
+    async def list_notifications(self, filters: NotificationFilters) -> NotificationsRows:
+        """Notifications + per-destination ancestor chains, fetched together."""

--- a/packages/server/dbos_argus/db/postgres.py
+++ b/packages/server/dbos_argus/db/postgres.py
@@ -1,0 +1,711 @@
+"""Postgres `ArgusDB` adapter.
+
+Owns the asyncpg engine and every Postgres-flavored SQL string the endpoints
+need. The SQL is transcribed verbatim from the pre-adapter `main.py`; the only
+difference is that results are mapped into `rows.py` dataclasses rather than
+fed directly into Pydantic models.
+
+Missing-schema handling: if the `dbos.*` tables don't exist yet (no DBOS app
+has connected), reads return empty/sentinel values instead of raising. That
+matches the original behavior — the console renders an empty state.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from ..schema_dump import SchemaDump, dump_live_schema
+from ..settings import Settings
+from ..workflow_status import ACTIVE_STATUSES_SQL, ERROR_STATUSES_SQL
+from .base import ArgusDB
+from .rows import (
+    AncestorRow,
+    EventRow,
+    NotificationFilters,
+    NotificationRow,
+    NotificationsRows,
+    ResultRow,
+    ScheduleRow,
+    StatsRow,
+    StepRow,
+    ThroughputRow,
+    WorkflowDetailRows,
+    WorkflowFamilyRow,
+    WorkflowFilters,
+    WorkflowListRow,
+)
+
+# Bucket → date_trunc unit (interpolated into SQL — closed set).
+_BUCKET_UNIT: dict[str, str] = {"hour": "hour", "day": "day"}
+
+
+def _build_workflow_sql(grouped: bool, filters: WorkflowFilters) -> tuple[str, dict[str, object]]:
+    """Render the list-workflows SQL + bound params for the given filters.
+
+    In grouped mode, filters apply to the `roots` CTE only — matching roots
+    come along with their entire descendant tree. Each row's sort_path is the
+    accumulated started_ms from root down to itself — Postgres array ordering
+    then yields a DFS traversal with children sitting directly under their
+    parent.
+
+    In flat mode, filters apply to all workflows; no recursion, ordered by
+    started_at DESC.
+    """
+    params: dict[str, object] = {"limit": filters.limit}
+    # Conditions that scope what counts as a "root" in grouped mode (and match
+    # rows directly in flat mode). `q` is handled separately because in grouped
+    # mode we want it to match anywhere in the tree, not just at the root.
+    root_conditions: list[str] = []
+
+    if filters.started_after_ms is not None:
+        root_conditions.append("COALESCE(started_at_epoch_ms, created_at) >= :started_after_ms")
+        params["started_after_ms"] = filters.started_after_ms
+    if filters.started_before_ms is not None:
+        root_conditions.append("COALESCE(started_at_epoch_ms, created_at) <= :started_before_ms")
+        params["started_before_ms"] = filters.started_before_ms
+    if filters.statuses:
+        root_conditions.append("status = ANY(:statuses)")
+        params["statuses"] = filters.statuses
+    else:
+        # ENQUEUED runs are surfaced in the workflow-list page's pinned strip,
+        # so the main list defaults to hiding them. An explicit `status` filter
+        # opts back in (the strip uses ?status=ENQUEUED).
+        root_conditions.append("status <> 'ENQUEUED'")
+    if filters.queue_name:
+        root_conditions.append("queue_name = :queue_name")
+        params["queue_name"] = filters.queue_name
+    # Scheduled workflow runs use the deterministic id `sched-<schedule_name>-<isoformat>`
+    # (or `sched-<func_name>-<isoformat>` from the deprecated decorator path). DBOS does
+    # not record an explicit "is scheduled" flag on workflow_status, so filtering by id
+    # prefix is the canonical detection — see dbos/_scheduler.py:171.
+    if filters.hide_scheduled:
+        root_conditions.append("workflow_uuid NOT LIKE 'sched-%'")
+
+    has_q = bool(filters.q)
+    if has_q:
+        params["q_pat"] = f"%{filters.q}%"
+
+    where_extra = (" AND " + " AND ".join(root_conditions)) if root_conditions else ""
+
+    # Operation counts come from a single GROUP BY scoped to the workflow_uuids
+    # we're returning — much cheaper than N+1 correlated subqueries on large
+    # operation_outputs tables.
+    if grouped:
+        # In grouped mode `q` matches at any depth: find any workflow whose
+        # uuid/name matches, walk up parent_workflow_id to find its root, then
+        # include that root's full subtree below. Without this, searching for
+        # a child name (e.g. "dispatch") would miss roots whose own name
+        # doesn't contain the term.
+        if has_q:
+            match_ctes = """
+                upward AS (
+                    SELECT workflow_uuid, parent_workflow_id
+                    FROM dbos.workflow_status
+                    WHERE workflow_uuid ILIKE :q_pat OR name ILIKE :q_pat
+                    UNION
+                    SELECT ws.workflow_uuid, ws.parent_workflow_id
+                    FROM dbos.workflow_status ws
+                    JOIN upward u ON u.parent_workflow_id = ws.workflow_uuid
+                ),
+                matched_roots AS (
+                    SELECT DISTINCT workflow_uuid
+                    FROM upward
+                    WHERE parent_workflow_id IS NULL
+                ),
+            """
+            match_filter = " AND workflow_uuid IN (SELECT workflow_uuid FROM matched_roots)"
+        else:
+            match_ctes = ""
+            match_filter = ""
+        sql = f"""
+            WITH RECURSIVE
+                {match_ctes}roots AS (
+                    SELECT workflow_uuid, updated_at
+                    FROM dbos.workflow_status
+                    WHERE parent_workflow_id IS NULL{where_extra}{match_filter}
+                    ORDER BY updated_at DESC
+                    LIMIT :limit
+                ),
+                tree AS (
+                    SELECT
+                        ws.workflow_uuid,
+                        ws.parent_workflow_id,
+                        ws.name,
+                        ws.status,
+                        ws.queue_name,
+                        ws.executor_id,
+                        ws.priority,
+                        COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
+                        ws.updated_at AS updated_ms,
+                        0 AS depth,
+                        r.updated_at AS root_updated_at,
+                        ARRAY[COALESCE(ws.started_at_epoch_ms, ws.created_at)] AS sort_path
+                    FROM dbos.workflow_status ws
+                    JOIN roots r ON ws.workflow_uuid = r.workflow_uuid
+
+                    UNION ALL
+
+                    SELECT
+                        c.workflow_uuid,
+                        c.parent_workflow_id,
+                        c.name,
+                        c.status,
+                        c.queue_name,
+                        c.executor_id,
+                        c.priority,
+                        COALESCE(c.started_at_epoch_ms, c.created_at),
+                        c.updated_at,
+                        t.depth + 1,
+                        t.root_updated_at,
+                        t.sort_path || COALESCE(c.started_at_epoch_ms, c.created_at)
+                    FROM dbos.workflow_status c
+                    JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
+                ),
+                op_counts AS (
+                    SELECT workflow_uuid, COUNT(*)::bigint AS op_count
+                    FROM dbos.operation_outputs
+                    WHERE workflow_uuid IN (SELECT workflow_uuid FROM tree)
+                    GROUP BY workflow_uuid
+                )
+            SELECT
+                t.workflow_uuid, t.parent_workflow_id, t.name, t.status,
+                t.queue_name, t.executor_id, t.priority,
+                t.started_ms, t.updated_ms, t.depth,
+                COALESCE(oc.op_count, 0)::bigint AS op_count
+            FROM tree t
+            LEFT JOIN op_counts oc ON oc.workflow_uuid = t.workflow_uuid
+            ORDER BY t.root_updated_at DESC, t.sort_path ASC
+        """
+    else:
+        # Flat mode: each row is independent, so `q` filters rows directly
+        # alongside the other conditions.
+        flat_conditions = list(root_conditions)
+        if has_q:
+            flat_conditions.append("(workflow_uuid ILIKE :q_pat OR name ILIKE :q_pat)")
+        flat_where_extra = (" AND " + " AND ".join(flat_conditions)) if flat_conditions else ""
+        flat_where = f"WHERE 1=1{flat_where_extra}" if flat_where_extra else ""
+        sql = f"""
+            WITH chosen AS (
+                SELECT
+                    workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
+                    priority,
+                    COALESCE(started_at_epoch_ms, created_at) AS started_ms,
+                    updated_at AS updated_ms
+                FROM dbos.workflow_status
+                {flat_where}
+                ORDER BY COALESCE(started_at_epoch_ms, created_at) DESC
+                LIMIT :limit
+            ),
+            op_counts AS (
+                SELECT workflow_uuid, COUNT(*)::bigint AS op_count
+                FROM dbos.operation_outputs
+                WHERE workflow_uuid IN (SELECT workflow_uuid FROM chosen)
+                GROUP BY workflow_uuid
+            )
+            SELECT
+                c.workflow_uuid, c.parent_workflow_id, c.name, c.status,
+                c.queue_name, c.executor_id, c.priority,
+                c.started_ms, c.updated_ms,
+                0 AS depth,
+                COALESCE(oc.op_count, 0)::bigint AS op_count
+            FROM chosen c
+            LEFT JOIN op_counts oc ON oc.workflow_uuid = c.workflow_uuid
+            ORDER BY c.started_ms DESC
+        """
+    return sql, params
+
+
+_FAMILY_SQL = """
+    WITH RECURSIVE
+        up AS (
+            SELECT workflow_uuid, parent_workflow_id, 0 AS lvl
+            FROM dbos.workflow_status
+            WHERE workflow_uuid = :workflow_id
+
+            UNION ALL
+
+            SELECT ws.workflow_uuid, ws.parent_workflow_id, u.lvl + 1
+            FROM dbos.workflow_status ws
+            JOIN up u ON ws.workflow_uuid = u.parent_workflow_id
+        ),
+        root AS (
+            SELECT workflow_uuid
+            FROM up
+            ORDER BY lvl DESC
+            LIMIT 1
+        ),
+        tree AS (
+            SELECT
+                ws.workflow_uuid,
+                ws.parent_workflow_id,
+                ws.name,
+                ws.status,
+                ws.queue_name,
+                ws.executor_id,
+                ws.recovery_attempts,
+                ws.workflow_timeout_ms,
+                ws.output IS NOT NULL AS has_output,
+                ws.error IS NOT NULL AS has_error,
+                COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
+                ws.updated_at AS updated_ms,
+                0 AS depth,
+                ARRAY[COALESCE(ws.started_at_epoch_ms, ws.created_at)] AS sort_path
+            FROM dbos.workflow_status ws
+            JOIN root r ON ws.workflow_uuid = r.workflow_uuid
+
+            UNION ALL
+
+            SELECT
+                c.workflow_uuid,
+                c.parent_workflow_id,
+                c.name,
+                c.status,
+                c.queue_name,
+                c.executor_id,
+                c.recovery_attempts,
+                c.workflow_timeout_ms,
+                c.output IS NOT NULL,
+                c.error IS NOT NULL,
+                COALESCE(c.started_at_epoch_ms, c.created_at),
+                c.updated_at,
+                t.depth + 1,
+                t.sort_path || COALESCE(c.started_at_epoch_ms, c.created_at)
+            FROM dbos.workflow_status c
+            JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
+        )
+    SELECT
+        workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
+        recovery_attempts, workflow_timeout_ms,
+        has_output, has_error, started_ms, updated_ms, depth
+    FROM tree
+    ORDER BY sort_path ASC
+"""
+
+
+# Sleep rows store the raw wakeup-time string in `output`. We carry it through
+# under a dedicated alias so main.py can compute sleep_requested_ms in Python
+# without shipping every step's payload to the client.
+_STEPS_SQL = """
+    SELECT
+        o.workflow_uuid,
+        o.function_id,
+        o.function_name,
+        o.output IS NOT NULL AS has_output,
+        o.error IS NOT NULL AS has_error,
+        o.child_workflow_id,
+        o.started_at_epoch_ms,
+        o.completed_at_epoch_ms,
+        seh.key AS event_key,
+        CASE WHEN o.function_name = 'DBOS.sleep' THEN o.output END AS sleep_output_raw
+    FROM dbos.operation_outputs o
+    LEFT JOIN dbos.workflow_events_history seh
+        ON o.function_name = 'DBOS.setEvent'
+        AND seh.workflow_uuid = o.workflow_uuid
+        AND seh.function_id = o.function_id
+    WHERE o.workflow_uuid = ANY(:workflow_ids)
+    ORDER BY o.workflow_uuid, o.function_id ASC
+"""
+
+
+# Joins each `dbos.workflow_events` row (current value per key) to every
+# corresponding `dbos.workflow_events_history` row (one per setEvent call) and
+# to `dbos.operation_outputs` for the call's completed_at. One row per
+# historical set; the current value repeats per row and is collapsed in
+# Python below.
+_EVENTS_SQL = """
+    SELECT
+        we.workflow_uuid,
+        we.key,
+        we.value AS current_value,
+        we.serialization AS current_serialization,
+        weh.function_id,
+        weh.value AS history_value,
+        weh.serialization AS history_serialization,
+        o.completed_at_epoch_ms
+    FROM dbos.workflow_events we
+    LEFT JOIN dbos.workflow_events_history weh
+        ON weh.workflow_uuid = we.workflow_uuid AND weh.key = we.key
+    LEFT JOIN dbos.operation_outputs o
+        ON o.workflow_uuid = weh.workflow_uuid
+            AND o.function_id = weh.function_id
+    WHERE we.workflow_uuid = ANY(:workflow_ids)
+    ORDER BY we.workflow_uuid, we.key, weh.function_id ASC
+"""
+
+
+_WORKFLOW_RESULT_SQL = """
+    SELECT output, error, serialization
+    FROM dbos.workflow_status
+    WHERE workflow_uuid = :workflow_id
+"""
+
+
+_STEP_RESULT_SQL = """
+    SELECT output, error, serialization
+    FROM dbos.operation_outputs
+    WHERE workflow_uuid = :workflow_id AND function_id = :function_id
+"""
+
+
+_STATS_SQL = f"""
+    SELECT
+        (SELECT COUNT(*) FROM dbos.workflow_status) AS total,
+        (SELECT COUNT(*) FROM dbos.workflow_status
+            WHERE status IN {ACTIVE_STATUSES_SQL}) AS in_flight,
+        (SELECT COUNT(*) FROM dbos.workflow_status
+            WHERE status = 'ENQUEUED') AS enqueued,
+        (SELECT COUNT(*) FROM dbos.workflow_status
+            WHERE status IN {ERROR_STATUSES_SQL}
+            AND COALESCE(started_at_epoch_ms, created_at) >= :since_ms) AS failed_recent,
+        (SELECT COUNT(*) FROM dbos.notifications
+            WHERE consumed = false) AS pending_notifications,
+        (SELECT COUNT(*) FROM dbos.workflow_schedules
+            WHERE status = 'ACTIVE') AS active_schedules
+"""
+
+
+_SCHEDULES_SQL = """
+    SELECT
+        schedule_id, schedule_name, workflow_name, workflow_class_name,
+        schedule, status, last_fired_at, automatic_backfill,
+        cron_timezone, queue_name
+    FROM dbos.workflow_schedules
+    ORDER BY schedule_name ASC
+"""
+
+
+# Walks parent_workflow_id from each destination up to the topmost ancestor in
+# one set-based recursive CTE. Tracks the seed destination so results can be
+# grouped per-notification client-side.
+_NOTIFICATION_ANCESTORS_SQL = """
+    WITH RECURSIVE up AS (
+        SELECT
+            ws.workflow_uuid AS seed_id,
+            ws.workflow_uuid,
+            ws.parent_workflow_id,
+            ws.name,
+            ws.status,
+            0 AS lvl
+        FROM dbos.workflow_status ws
+        WHERE ws.workflow_uuid = ANY(:destination_ids)
+
+        UNION ALL
+
+        SELECT
+            u.seed_id,
+            ws.workflow_uuid,
+            ws.parent_workflow_id,
+            ws.name,
+            ws.status,
+            u.lvl + 1
+        FROM dbos.workflow_status ws
+        JOIN up u ON ws.workflow_uuid = u.parent_workflow_id
+    )
+    SELECT seed_id, workflow_uuid, name, status, lvl
+    FROM up
+    ORDER BY seed_id, lvl DESC
+"""
+
+
+_EMPTY_STATS = StatsRow(
+    total=0,
+    in_flight=0,
+    enqueued=0,
+    failed_recent=0,
+    pending_notifications=0,
+    active_schedules=0,
+)
+
+
+class PostgresArgusDB(ArgusDB):
+    """asyncpg-backed adapter for DBOS Postgres system databases."""
+
+    def __init__(self, settings: Settings) -> None:
+        url, connect_args = settings.asyncpg_engine_args()
+        self.engine = create_async_engine(url, echo=False, future=True, connect_args=connect_args)
+
+    @property
+    def display_url(self) -> str:
+        return self.engine.url.render_as_string(hide_password=True)
+
+    async def healthcheck(self) -> None:
+        async with self.engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+
+    async def reflect_schema(self, schema: str = "dbos") -> SchemaDump:
+        async with self.engine.connect() as conn:
+            return await dump_live_schema(conn, schema=schema)
+
+    async def list_workflows(self, filters: WorkflowFilters) -> list[WorkflowListRow]:
+        sql, params = _build_workflow_sql(filters.grouped, filters)
+        try:
+            async with self.engine.connect() as conn:
+                result = await conn.execute(text(sql), params)
+                rows = result.fetchall()
+        except ProgrammingError:
+            return []
+        return [
+            WorkflowListRow(
+                workflow_uuid=r.workflow_uuid,
+                parent_workflow_id=r.parent_workflow_id,
+                name=r.name,
+                status=r.status,
+                queue_name=r.queue_name,
+                executor_id=r.executor_id,
+                priority=r.priority,
+                started_ms=r.started_ms,
+                updated_ms=r.updated_ms,
+                depth=r.depth,
+                op_count=r.op_count,
+            )
+            for r in rows
+        ]
+
+    async def get_workflow_detail(self, workflow_id: str) -> WorkflowDetailRows:
+        try:
+            async with self.engine.connect() as conn:
+                family_rows = (
+                    await conn.execute(text(_FAMILY_SQL), {"workflow_id": workflow_id})
+                ).fetchall()
+                family_ids = [r.workflow_uuid for r in family_rows]
+                step_rows = (
+                    await conn.execute(text(_STEPS_SQL), {"workflow_ids": family_ids})
+                ).fetchall()
+                event_rows = (
+                    await conn.execute(text(_EVENTS_SQL), {"workflow_ids": family_ids})
+                ).fetchall()
+        except ProgrammingError:
+            return WorkflowDetailRows(family=[], steps=[], events=[])
+
+        family = [
+            WorkflowFamilyRow(
+                workflow_uuid=r.workflow_uuid,
+                parent_workflow_id=r.parent_workflow_id,
+                name=r.name,
+                status=r.status,
+                queue_name=r.queue_name,
+                executor_id=r.executor_id,
+                recovery_attempts=r.recovery_attempts,
+                workflow_timeout_ms=r.workflow_timeout_ms,
+                has_output=r.has_output,
+                has_error=r.has_error,
+                started_ms=r.started_ms,
+                updated_ms=r.updated_ms,
+                depth=r.depth,
+            )
+            for r in family_rows
+        ]
+        steps = [
+            StepRow(
+                workflow_uuid=s.workflow_uuid,
+                function_id=s.function_id,
+                function_name=s.function_name,
+                has_output=s.has_output,
+                has_error=s.has_error,
+                child_workflow_id=s.child_workflow_id,
+                started_at_epoch_ms=s.started_at_epoch_ms,
+                completed_at_epoch_ms=s.completed_at_epoch_ms,
+                event_key=s.event_key,
+                sleep_output_raw=s.sleep_output_raw,
+            )
+            for s in step_rows
+        ]
+        events = [
+            EventRow(
+                workflow_uuid=e.workflow_uuid,
+                key=e.key,
+                current_value=e.current_value,
+                current_serialization=e.current_serialization,
+                function_id=e.function_id,
+                history_value=e.history_value,
+                history_serialization=e.history_serialization,
+                completed_at_epoch_ms=e.completed_at_epoch_ms,
+            )
+            for e in event_rows
+        ]
+        return WorkflowDetailRows(family=family, steps=steps, events=events)
+
+    async def get_workflow_result(self, workflow_id: str) -> ResultRow | None:
+        try:
+            async with self.engine.connect() as conn:
+                row = (
+                    await conn.execute(text(_WORKFLOW_RESULT_SQL), {"workflow_id": workflow_id})
+                ).fetchone()
+        except ProgrammingError:
+            return None
+        if row is None:
+            return None
+        return ResultRow(output=row.output, error=row.error, serialization=row.serialization)
+
+    async def get_step_result(self, workflow_id: str, function_id: int) -> ResultRow | None:
+        try:
+            async with self.engine.connect() as conn:
+                row = (
+                    await conn.execute(
+                        text(_STEP_RESULT_SQL),
+                        {"workflow_id": workflow_id, "function_id": function_id},
+                    )
+                ).fetchone()
+        except ProgrammingError:
+            return None
+        if row is None:
+            return None
+        return ResultRow(output=row.output, error=row.error, serialization=row.serialization)
+
+    async def get_stats(self, since_ms: int) -> StatsRow:
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(_STATS_SQL), {"since_ms": since_ms})).fetchone()
+        except ProgrammingError:
+            return _EMPTY_STATS
+        if row is None:
+            return _EMPTY_STATS
+        return StatsRow(
+            total=row.total,
+            in_flight=row.in_flight,
+            enqueued=row.enqueued,
+            failed_recent=row.failed_recent,
+            pending_notifications=row.pending_notifications,
+            active_schedules=row.active_schedules,
+        )
+
+    async def get_throughput(
+        self, since_ms: int, until_ms: int, bucket: Literal["hour", "day"]
+    ) -> list[ThroughputRow]:
+        unit = _BUCKET_UNIT[bucket]
+        # Bucket unit comes from a closed literal mapping above — safe to interpolate.
+        sql = f"""
+            WITH params AS (
+                SELECT
+                    CAST(:since_ms AS bigint) AS since_ms,
+                    CAST(:until_ms AS bigint) AS until_ms
+            ),
+            buckets AS (
+                SELECT generate_series(
+                    date_trunc('{unit}', to_timestamp(p.since_ms / 1000.0)),
+                    date_trunc('{unit}', to_timestamp(p.until_ms / 1000.0)),
+                    '1 {unit}'::interval
+                ) AS ts
+                FROM params p
+            ),
+            events AS (
+                SELECT
+                    date_trunc('{unit}', to_timestamp(ws.created_at / 1000.0)) AS ts,
+                    ws.status
+                FROM dbos.workflow_status ws, params p
+                WHERE ws.created_at >= p.since_ms AND ws.created_at <= p.until_ms
+            )
+            SELECT
+                b.ts AS ts,
+                COUNT(e.*) FILTER (WHERE e.status = 'SUCCESS') AS succeeded,
+                COUNT(e.*) FILTER (WHERE e.status IN {ERROR_STATUSES_SQL}) AS errored,
+                COUNT(e.*) FILTER (WHERE e.status IN {ACTIVE_STATUSES_SQL}) AS running
+            FROM buckets b
+            LEFT JOIN events e ON e.ts = b.ts
+            GROUP BY b.ts
+            ORDER BY b.ts ASC
+        """
+        try:
+            async with self.engine.connect() as conn:
+                rows = (
+                    await conn.execute(text(sql), {"since_ms": since_ms, "until_ms": until_ms})
+                ).fetchall()
+        except ProgrammingError:
+            return []
+        return [
+            ThroughputRow(
+                ts=r.ts,
+                succeeded=r.succeeded,
+                errored=r.errored,
+                running=r.running,
+            )
+            for r in rows
+        ]
+
+    async def list_schedules(self) -> list[ScheduleRow]:
+        try:
+            async with self.engine.connect() as conn:
+                rows = (await conn.execute(text(_SCHEDULES_SQL))).fetchall()
+        except ProgrammingError:
+            return []
+        return [
+            ScheduleRow(
+                schedule_id=r.schedule_id,
+                schedule_name=r.schedule_name,
+                workflow_name=r.workflow_name,
+                workflow_class_name=r.workflow_class_name,
+                schedule=r.schedule,
+                status=r.status,
+                last_fired_at=r.last_fired_at,
+                automatic_backfill=r.automatic_backfill,
+                cron_timezone=r.cron_timezone,
+                queue_name=r.queue_name,
+            )
+            for r in rows
+        ]
+
+    async def list_notifications(self, filters: NotificationFilters) -> NotificationsRows:
+        conditions: list[str] = []
+        params: dict[str, object] = {"limit": filters.limit}
+        if filters.consumed is not None:
+            conditions.append("consumed = :consumed")
+            params["consumed"] = filters.consumed
+        if filters.destination_uuid:
+            conditions.append("destination_uuid = :destination_uuid")
+            params["destination_uuid"] = filters.destination_uuid
+        if filters.topic:
+            conditions.append("topic = :topic")
+            params["topic"] = filters.topic
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        sql = f"""
+            SELECT message_uuid, destination_uuid, topic, consumed, created_at_epoch_ms,
+                   message, serialization
+            FROM dbos.notifications
+            {where}
+            ORDER BY created_at_epoch_ms DESC
+            LIMIT :limit
+        """
+        try:
+            async with self.engine.connect() as conn:
+                rows = (await conn.execute(text(sql), params)).fetchall()
+                destination_ids = list({r.destination_uuid for r in rows})
+                ancestor_rows = (
+                    (
+                        await conn.execute(
+                            text(_NOTIFICATION_ANCESTORS_SQL),
+                            {"destination_ids": destination_ids},
+                        )
+                    ).fetchall()
+                    if destination_ids
+                    else []
+                )
+        except ProgrammingError:
+            return NotificationsRows(notifications=[], ancestors=[])
+
+        notifications = [
+            NotificationRow(
+                message_uuid=r.message_uuid,
+                destination_uuid=r.destination_uuid,
+                topic=r.topic,
+                consumed=r.consumed,
+                created_at_epoch_ms=r.created_at_epoch_ms,
+                message=r.message,
+                serialization=r.serialization,
+            )
+            for r in rows
+        ]
+        ancestors = [
+            AncestorRow(
+                seed_id=ar.seed_id,
+                workflow_uuid=ar.workflow_uuid,
+                name=ar.name,
+                status=ar.status,
+                lvl=ar.lvl,
+            )
+            for ar in ancestor_rows
+        ]
+        return NotificationsRows(notifications=notifications, ancestors=ancestors)

--- a/packages/server/dbos_argus/db/rows.py
+++ b/packages/server/dbos_argus/db/rows.py
@@ -1,0 +1,164 @@
+"""Typed row & filter shapes that the `ArgusDB` adapter exposes.
+
+Adapters return these dataclasses; `main.py` maps them to the public Pydantic
+response models. They mirror the columns each endpoint actually needs — the
+`*_ms` integers are unix epoch milliseconds (DBOS' native time unit), so
+adapters can stay dialect-neutral about timestamp conversion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class WorkflowFilters:
+    limit: int = 50
+    q: str | None = None
+    started_after_ms: int | None = None
+    started_before_ms: int | None = None
+    statuses: list[str] | None = None
+    queue_name: str | None = None
+    hide_scheduled: bool = False
+    grouped: bool = True
+
+
+@dataclass(frozen=True)
+class NotificationFilters:
+    limit: int = 200
+    consumed: bool | None = None
+    destination_uuid: str | None = None
+    topic: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowListRow:
+    workflow_uuid: str
+    parent_workflow_id: str | None
+    name: str | None
+    status: str | None
+    queue_name: str | None
+    executor_id: str | None
+    priority: int | None
+    started_ms: int
+    updated_ms: int
+    depth: int
+    op_count: int
+
+
+@dataclass(frozen=True)
+class WorkflowFamilyRow:
+    workflow_uuid: str
+    parent_workflow_id: str | None
+    name: str | None
+    status: str | None
+    queue_name: str | None
+    executor_id: str | None
+    recovery_attempts: int | None
+    workflow_timeout_ms: int | None
+    has_output: bool
+    has_error: bool
+    started_ms: int
+    updated_ms: int
+    depth: int
+
+
+@dataclass(frozen=True)
+class StepRow:
+    workflow_uuid: str
+    function_id: int
+    function_name: str | None
+    has_output: bool
+    has_error: bool
+    child_workflow_id: str | None
+    started_at_epoch_ms: int | None
+    completed_at_epoch_ms: int | None
+    event_key: str | None
+    # Raw `output` for `DBOS.sleep` rows — main.py turns it into the
+    # originally-requested duration. Always None for non-sleep rows.
+    sleep_output_raw: str | None
+
+
+@dataclass(frozen=True)
+class EventRow:
+    workflow_uuid: str
+    key: str
+    current_value: str
+    current_serialization: str | None
+    function_id: int | None
+    history_value: str | None
+    history_serialization: str | None
+    completed_at_epoch_ms: int | None
+
+
+@dataclass(frozen=True)
+class WorkflowDetailRows:
+    family: list[WorkflowFamilyRow]
+    steps: list[StepRow]
+    events: list[EventRow]
+
+
+@dataclass(frozen=True)
+class ResultRow:
+    output: str | None
+    error: str | None
+    serialization: str | None
+
+
+@dataclass(frozen=True)
+class StatsRow:
+    total: int
+    in_flight: int
+    enqueued: int
+    failed_recent: int
+    pending_notifications: int
+    active_schedules: int
+
+
+@dataclass(frozen=True)
+class ThroughputRow:
+    ts: datetime
+    succeeded: int
+    errored: int
+    running: int
+
+
+@dataclass(frozen=True)
+class ScheduleRow:
+    schedule_id: str
+    schedule_name: str
+    workflow_name: str
+    workflow_class_name: str | None
+    schedule: str
+    status: str
+    last_fired_at: str | None
+    automatic_backfill: bool
+    cron_timezone: str | None
+    queue_name: str | None
+
+
+@dataclass(frozen=True)
+class NotificationRow:
+    message_uuid: str
+    destination_uuid: str
+    topic: str | None
+    consumed: bool
+    created_at_epoch_ms: int
+    message: str | None
+    serialization: str | None
+
+
+@dataclass(frozen=True)
+class AncestorRow:
+    seed_id: str
+    workflow_uuid: str
+    name: str | None
+    status: str | None
+    lvl: int
+
+
+@dataclass(frozen=True)
+class NotificationsRows:
+    notifications: list[NotificationRow]
+    ancestors: list[AncestorRow]

--- a/packages/server/dbos_argus/db/sqlite.py
+++ b/packages/server/dbos_argus/db/sqlite.py
@@ -1,0 +1,886 @@
+"""SQLite `ArgusDB` adapter.
+
+DBOS' SQLite system database is column-compatible with the Postgres one
+(`dbos/_migration.py:sqlite_migrations`), but the SQL dialects diverge enough
+that the read queries are written separately rather than templated. The
+biggest deltas vs `postgres.py`:
+
+* SQLite has no schema namespace — tables live in the main DB, no `dbos.`
+  prefix.
+* No array operators (`ANY`, `ARRAY[]`, `||`). For `IN (...)` we use
+  SQLAlchemy expanding bindparams; for the recursive workflow tree we drop
+  the in-SQL `sort_path` and run the DFS sort in Python.
+* No `ILIKE` — SQLite's `LIKE` is already case-insensitive for ASCII, which
+  is what our uuid/name searches need.
+* No `generate_series` / `date_trunc` / `to_timestamp`. The throughput
+  endpoint buckets in Python instead.
+* No `information_schema`. Reflection goes through `sqlite_master` +
+  `pragma_table_info`, with sqlite type strings normalized into the same
+  vocabulary the packaged Postgres snapshot uses so the diff comparator can
+  stay shared.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Literal
+
+from sqlalchemy import bindparam, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+
+from ..schema_dump import ColumnInfo, SchemaDump, TableInfo
+from ..settings import Settings
+from ..workflow_status import ACTIVE_STATUSES, ERROR_STATUSES
+from .base import ArgusDB
+from .rows import (
+    AncestorRow,
+    EventRow,
+    NotificationFilters,
+    NotificationRow,
+    NotificationsRows,
+    ResultRow,
+    ScheduleRow,
+    StatsRow,
+    StepRow,
+    ThroughputRow,
+    WorkflowDetailRows,
+    WorkflowFamilyRow,
+    WorkflowFilters,
+    WorkflowListRow,
+)
+
+# Bucket → millisecond width. Buckets are aligned to UTC midnight / hour-zero
+# via integer division of `created_at` (which DBOS stores as epoch ms) so we
+# don't need a calendar-aware truncation.
+_BUCKET_MS: dict[str, int] = {
+    "hour": 3_600_000,
+    "day": 86_400_000,
+}
+
+
+# SQLite's pragma_table_info reports the type string the migration declared.
+# Normalize to the lowercase Postgres-snapshot vocabulary so `schema_diff` can
+# compare them without per-dialect knowledge. Whatever isn't here is passed
+# through lowercased — the diff already accepts text/character-varying as
+# synonyms, and unknown types will surface as type mismatches.
+_SQLITE_TYPE_NORMALIZE: dict[str, str] = {
+    # SQLite INTEGER is variable-width up to 8 bytes — the same range as
+    # Postgres bigint, which is what the DBOS snapshot pins for epoch-ms
+    # columns. Using "bigint" keeps the diff happy on existing argus columns.
+    "integer": "bigint",
+    "bigint": "bigint",
+    "int4": "integer",
+    "text": "text",
+    "boolean": "boolean",
+    "numeric": "numeric",
+    "real": "double precision",
+    "blob": "bytea",
+}
+
+
+def _normalize_sqlite_type(declared: str) -> str:
+    base = declared.strip().lower()
+    # "varchar(255)" → "varchar"; "numeric(38,15)" → "numeric"
+    paren = base.find("(")
+    if paren != -1:
+        base = base[:paren].rstrip()
+    if base in ("varchar", "char", "character varying", "character"):
+        # treat as text-equivalent (the existing diff synonym group catches this)
+        return "character varying"
+    return _SQLITE_TYPE_NORMALIZE.get(base, base)
+
+
+def _expanding(name: str) -> bindparam:
+    return bindparam(name, expanding=True)
+
+
+_EMPTY_STATS = StatsRow(
+    total=0,
+    in_flight=0,
+    enqueued=0,
+    failed_recent=0,
+    pending_notifications=0,
+    active_schedules=0,
+)
+
+
+class SqliteArgusDB(ArgusDB):
+    """aiosqlite-backed adapter for DBOS SQLite system databases."""
+
+    def __init__(self, settings: Settings) -> None:
+        # asyncpg-style query-arg massaging (sslmode, libpq options) is
+        # Postgres-only; SQLite URLs are passed through to SQLAlchemy verbatim.
+        self.engine = create_async_engine(settings.database_url, echo=False, future=True)
+
+    @property
+    def display_url(self) -> str:
+        return self.engine.url.render_as_string(hide_password=True)
+
+    async def healthcheck(self) -> None:
+        async with self.engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+
+    async def reflect_schema(self, schema: str = "dbos") -> SchemaDump:
+        async with self.engine.connect() as conn:
+            table_rows = (
+                await conn.execute(
+                    text(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type='table' AND name NOT LIKE 'sqlite_%' "
+                        "ORDER BY name"
+                    )
+                )
+            ).fetchall()
+
+            tables: list[TableInfo] = []
+            for tr in table_rows:
+                table_name = tr[0]
+                # PRAGMA can't be parameterized; the table name comes from
+                # sqlite_master so it's safe to interpolate.
+                col_rows = (
+                    await conn.execute(text(f"PRAGMA table_info('{table_name}')"))
+                ).fetchall()
+                columns = tuple(
+                    ColumnInfo(
+                        name=cr[1],
+                        data_type=_normalize_sqlite_type(cr[2] or ""),
+                    )
+                    for cr in col_rows
+                )
+                tables.append(TableInfo(name=table_name, columns=columns))
+
+        # `schema` is echoed back so the diff against the Postgres snapshot
+        # can match `expected.schema == "dbos"`. SQLite has no namespace, so
+        # the value is decorative.
+        return SchemaDump(schema=schema, tables=tuple(tables))
+
+    async def list_workflows(self, filters: WorkflowFilters) -> list[WorkflowListRow]:
+        try:
+            async with self.engine.connect() as conn:
+                rows = await self._list_workflows(conn, filters)
+        except OperationalError:
+            return []
+        return rows
+
+    async def _list_workflows(
+        self, conn: AsyncConnection, filters: WorkflowFilters
+    ) -> list[WorkflowListRow]:
+        # Build the same root-conditions set the Postgres adapter uses.
+        params: dict[str, object] = {"limit": filters.limit}
+        root_conditions: list[str] = []
+
+        if filters.started_after_ms is not None:
+            root_conditions.append("COALESCE(started_at_epoch_ms, created_at) >= :started_after_ms")
+            params["started_after_ms"] = filters.started_after_ms
+        if filters.started_before_ms is not None:
+            root_conditions.append(
+                "COALESCE(started_at_epoch_ms, created_at) <= :started_before_ms"
+            )
+            params["started_before_ms"] = filters.started_before_ms
+
+        statuses_bind = None
+        if filters.statuses:
+            root_conditions.append("status IN :statuses")
+            params["statuses"] = filters.statuses
+            statuses_bind = _expanding("statuses")
+        else:
+            root_conditions.append("status <> 'ENQUEUED'")
+
+        if filters.queue_name:
+            root_conditions.append("queue_name = :queue_name")
+            params["queue_name"] = filters.queue_name
+        if filters.hide_scheduled:
+            root_conditions.append("workflow_uuid NOT LIKE 'sched-%'")
+
+        has_q = bool(filters.q)
+        if has_q:
+            params["q_pat"] = f"%{filters.q}%"
+
+        where_extra = (" AND " + " AND ".join(root_conditions)) if root_conditions else ""
+
+        if filters.grouped:
+            if has_q:
+                # Find any workflow matching `q`, walk up to its root, include
+                # the root's whole subtree below — same pattern as Postgres.
+                match_ctes = """
+                    upward AS (
+                        SELECT workflow_uuid, parent_workflow_id
+                        FROM workflow_status
+                        WHERE workflow_uuid LIKE :q_pat OR name LIKE :q_pat
+                        UNION
+                        SELECT ws.workflow_uuid, ws.parent_workflow_id
+                        FROM workflow_status ws
+                        JOIN upward u ON u.parent_workflow_id = ws.workflow_uuid
+                    ),
+                    matched_roots AS (
+                        SELECT DISTINCT workflow_uuid
+                        FROM upward
+                        WHERE parent_workflow_id IS NULL
+                    ),
+                """
+                match_filter = " AND workflow_uuid IN (SELECT workflow_uuid FROM matched_roots)"
+            else:
+                match_ctes = ""
+                match_filter = ""
+
+            sql = f"""
+                WITH RECURSIVE
+                    {match_ctes}roots AS (
+                        SELECT workflow_uuid, updated_at
+                        FROM workflow_status
+                        WHERE parent_workflow_id IS NULL{where_extra}{match_filter}
+                        ORDER BY updated_at DESC
+                        LIMIT :limit
+                    ),
+                    tree AS (
+                        SELECT
+                            ws.workflow_uuid,
+                            ws.parent_workflow_id,
+                            ws.name,
+                            ws.status,
+                            ws.queue_name,
+                            ws.executor_id,
+                            ws.priority,
+                            COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
+                            ws.updated_at AS updated_ms,
+                            0 AS depth,
+                            r.updated_at AS root_updated_at,
+                            ws.workflow_uuid AS root_uuid
+                        FROM workflow_status ws
+                        JOIN roots r ON ws.workflow_uuid = r.workflow_uuid
+
+                        UNION ALL
+
+                        SELECT
+                            c.workflow_uuid,
+                            c.parent_workflow_id,
+                            c.name,
+                            c.status,
+                            c.queue_name,
+                            c.executor_id,
+                            c.priority,
+                            COALESCE(c.started_at_epoch_ms, c.created_at),
+                            c.updated_at,
+                            t.depth + 1,
+                            t.root_updated_at,
+                            t.root_uuid
+                        FROM workflow_status c
+                        JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
+                    )
+                SELECT
+                    t.workflow_uuid, t.parent_workflow_id, t.name, t.status,
+                    t.queue_name, t.executor_id, t.priority,
+                    t.started_ms, t.updated_ms, t.depth,
+                    t.root_updated_at, t.root_uuid,
+                    COALESCE(oc.op_count, 0) AS op_count
+                FROM tree t
+                LEFT JOIN (
+                    SELECT workflow_uuid, COUNT(*) AS op_count
+                    FROM operation_outputs
+                    WHERE workflow_uuid IN (SELECT workflow_uuid FROM tree)
+                    GROUP BY workflow_uuid
+                ) oc ON oc.workflow_uuid = t.workflow_uuid
+            """
+            stmt = text(sql)
+            if statuses_bind is not None:
+                stmt = stmt.bindparams(statuses_bind)
+            rows = (await conn.execute(stmt, params)).fetchall()
+
+            # Postgres uses `ORDER BY root_updated_at DESC, sort_path ASC` to
+            # produce a DFS layout. SQLite has no array sort, so we sort here
+            # in Python: group rows by root, order roots by root_updated_at
+            # DESC, then DFS within each root by started_ms.
+            return _dfs_grouped(rows)
+
+        # Flat mode — same conditions, no recursion, ordered by started DESC.
+        flat_conditions = list(root_conditions)
+        if has_q:
+            flat_conditions.append("(workflow_uuid LIKE :q_pat OR name LIKE :q_pat)")
+        flat_where_extra = " AND " + " AND ".join(flat_conditions) if flat_conditions else ""
+        flat_where = f"WHERE 1=1{flat_where_extra}" if flat_where_extra else ""
+        sql = f"""
+            WITH chosen AS (
+                SELECT
+                    workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
+                    priority,
+                    COALESCE(started_at_epoch_ms, created_at) AS started_ms,
+                    updated_at AS updated_ms
+                FROM workflow_status
+                {flat_where}
+                ORDER BY COALESCE(started_at_epoch_ms, created_at) DESC
+                LIMIT :limit
+            )
+            SELECT
+                c.workflow_uuid, c.parent_workflow_id, c.name, c.status,
+                c.queue_name, c.executor_id, c.priority,
+                c.started_ms, c.updated_ms,
+                0 AS depth,
+                COALESCE(oc.op_count, 0) AS op_count
+            FROM chosen c
+            LEFT JOIN (
+                SELECT workflow_uuid, COUNT(*) AS op_count
+                FROM operation_outputs
+                WHERE workflow_uuid IN (SELECT workflow_uuid FROM chosen)
+                GROUP BY workflow_uuid
+            ) oc ON oc.workflow_uuid = c.workflow_uuid
+            ORDER BY c.started_ms DESC
+        """
+        stmt = text(sql)
+        if statuses_bind is not None:
+            stmt = stmt.bindparams(statuses_bind)
+        rows = (await conn.execute(stmt, params)).fetchall()
+        return [
+            WorkflowListRow(
+                workflow_uuid=r.workflow_uuid,
+                parent_workflow_id=r.parent_workflow_id,
+                name=r.name,
+                status=r.status,
+                queue_name=r.queue_name,
+                executor_id=r.executor_id,
+                priority=r.priority,
+                started_ms=r.started_ms,
+                updated_ms=r.updated_ms,
+                depth=r.depth,
+                op_count=r.op_count,
+            )
+            for r in rows
+        ]
+
+    async def get_workflow_detail(self, workflow_id: str) -> WorkflowDetailRows:
+        try:
+            async with self.engine.connect() as conn:
+                family_rows_raw = (
+                    await conn.execute(
+                        text(
+                            """
+                            WITH RECURSIVE
+                                up AS (
+                                    SELECT workflow_uuid, parent_workflow_id, 0 AS lvl
+                                    FROM workflow_status
+                                    WHERE workflow_uuid = :workflow_id
+
+                                    UNION ALL
+
+                                    SELECT ws.workflow_uuid, ws.parent_workflow_id, u.lvl + 1
+                                    FROM workflow_status ws
+                                    JOIN up u ON ws.workflow_uuid = u.parent_workflow_id
+                                ),
+                                root AS (
+                                    SELECT workflow_uuid
+                                    FROM up
+                                    ORDER BY lvl DESC
+                                    LIMIT 1
+                                ),
+                                tree AS (
+                                    SELECT
+                                        ws.workflow_uuid,
+                                        ws.parent_workflow_id,
+                                        ws.name,
+                                        ws.status,
+                                        ws.queue_name,
+                                        ws.executor_id,
+                                        ws.recovery_attempts,
+                                        ws.workflow_timeout_ms,
+                                        ws.output IS NOT NULL AS has_output,
+                                        ws.error IS NOT NULL AS has_error,
+                                        COALESCE(ws.started_at_epoch_ms, ws.created_at)
+                                            AS started_ms,
+                                        ws.updated_at AS updated_ms,
+                                        0 AS depth
+                                    FROM workflow_status ws
+                                    JOIN root r ON ws.workflow_uuid = r.workflow_uuid
+
+                                    UNION ALL
+
+                                    SELECT
+                                        c.workflow_uuid,
+                                        c.parent_workflow_id,
+                                        c.name,
+                                        c.status,
+                                        c.queue_name,
+                                        c.executor_id,
+                                        c.recovery_attempts,
+                                        c.workflow_timeout_ms,
+                                        c.output IS NOT NULL,
+                                        c.error IS NOT NULL,
+                                        COALESCE(c.started_at_epoch_ms, c.created_at),
+                                        c.updated_at,
+                                        t.depth + 1
+                                    FROM workflow_status c
+                                    JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
+                                )
+                            SELECT * FROM tree
+                            """
+                        ),
+                        {"workflow_id": workflow_id},
+                    )
+                ).fetchall()
+
+                family_sorted = _dfs_family(family_rows_raw)
+                family_ids = [r.workflow_uuid for r in family_sorted]
+
+                if not family_ids:
+                    return WorkflowDetailRows(family=[], steps=[], events=[])
+
+                steps_stmt = text(
+                    """
+                    SELECT
+                        o.workflow_uuid,
+                        o.function_id,
+                        o.function_name,
+                        o.output IS NOT NULL AS has_output,
+                        o.error IS NOT NULL AS has_error,
+                        o.child_workflow_id,
+                        o.started_at_epoch_ms,
+                        o.completed_at_epoch_ms,
+                        seh.key AS event_key,
+                        CASE WHEN o.function_name = 'DBOS.sleep' THEN o.output END
+                            AS sleep_output_raw
+                    FROM operation_outputs o
+                    LEFT JOIN workflow_events_history seh
+                        ON o.function_name = 'DBOS.setEvent'
+                        AND seh.workflow_uuid = o.workflow_uuid
+                        AND seh.function_id = o.function_id
+                    WHERE o.workflow_uuid IN :workflow_ids
+                    ORDER BY o.workflow_uuid, o.function_id ASC
+                    """
+                ).bindparams(_expanding("workflow_ids"))
+                step_rows = (
+                    await conn.execute(steps_stmt, {"workflow_ids": family_ids})
+                ).fetchall()
+
+                events_stmt = text(
+                    """
+                    SELECT
+                        we.workflow_uuid,
+                        we.key,
+                        we.value AS current_value,
+                        we.serialization AS current_serialization,
+                        weh.function_id,
+                        weh.value AS history_value,
+                        weh.serialization AS history_serialization,
+                        o.completed_at_epoch_ms
+                    FROM workflow_events we
+                    LEFT JOIN workflow_events_history weh
+                        ON weh.workflow_uuid = we.workflow_uuid AND weh.key = we.key
+                    LEFT JOIN operation_outputs o
+                        ON o.workflow_uuid = weh.workflow_uuid
+                            AND o.function_id = weh.function_id
+                    WHERE we.workflow_uuid IN :workflow_ids
+                    ORDER BY we.workflow_uuid, we.key, weh.function_id ASC
+                    """
+                ).bindparams(_expanding("workflow_ids"))
+                event_rows = (
+                    await conn.execute(events_stmt, {"workflow_ids": family_ids})
+                ).fetchall()
+        except OperationalError:
+            return WorkflowDetailRows(family=[], steps=[], events=[])
+
+        family = [
+            WorkflowFamilyRow(
+                workflow_uuid=r.workflow_uuid,
+                parent_workflow_id=r.parent_workflow_id,
+                name=r.name,
+                status=r.status,
+                queue_name=r.queue_name,
+                executor_id=r.executor_id,
+                recovery_attempts=r.recovery_attempts,
+                workflow_timeout_ms=r.workflow_timeout_ms,
+                has_output=bool(r.has_output),
+                has_error=bool(r.has_error),
+                started_ms=r.started_ms,
+                updated_ms=r.updated_ms,
+                depth=r.depth,
+            )
+            for r in family_sorted
+        ]
+        steps = [
+            StepRow(
+                workflow_uuid=s.workflow_uuid,
+                function_id=s.function_id,
+                function_name=s.function_name,
+                has_output=bool(s.has_output),
+                has_error=bool(s.has_error),
+                child_workflow_id=s.child_workflow_id,
+                started_at_epoch_ms=s.started_at_epoch_ms,
+                completed_at_epoch_ms=s.completed_at_epoch_ms,
+                event_key=s.event_key,
+                sleep_output_raw=s.sleep_output_raw,
+            )
+            for s in step_rows
+        ]
+        events = [
+            EventRow(
+                workflow_uuid=e.workflow_uuid,
+                key=e.key,
+                current_value=e.current_value,
+                current_serialization=e.current_serialization,
+                function_id=e.function_id,
+                history_value=e.history_value,
+                history_serialization=e.history_serialization,
+                completed_at_epoch_ms=e.completed_at_epoch_ms,
+            )
+            for e in event_rows
+        ]
+        return WorkflowDetailRows(family=family, steps=steps, events=events)
+
+    async def get_workflow_result(self, workflow_id: str) -> ResultRow | None:
+        try:
+            async with self.engine.connect() as conn:
+                row = (
+                    await conn.execute(
+                        text(
+                            "SELECT output, error, serialization FROM workflow_status "
+                            "WHERE workflow_uuid = :workflow_id"
+                        ),
+                        {"workflow_id": workflow_id},
+                    )
+                ).fetchone()
+        except OperationalError:
+            return None
+        if row is None:
+            return None
+        return ResultRow(output=row.output, error=row.error, serialization=row.serialization)
+
+    async def get_step_result(self, workflow_id: str, function_id: int) -> ResultRow | None:
+        try:
+            async with self.engine.connect() as conn:
+                row = (
+                    await conn.execute(
+                        text(
+                            "SELECT output, error, serialization FROM operation_outputs "
+                            "WHERE workflow_uuid = :workflow_id AND function_id = :function_id"
+                        ),
+                        {"workflow_id": workflow_id, "function_id": function_id},
+                    )
+                ).fetchone()
+        except OperationalError:
+            return None
+        if row is None:
+            return None
+        return ResultRow(output=row.output, error=row.error, serialization=row.serialization)
+
+    async def get_stats(self, since_ms: int) -> StatsRow:
+        try:
+            async with self.engine.connect() as conn:
+                # Each subquery uses an IN with an expanding bindparam. Names
+                # have to differ across binds (SQLAlchemy can't reuse the same
+                # expanding name in one statement).
+                stmt = text(
+                    """
+                    SELECT
+                        (SELECT COUNT(*) FROM workflow_status)
+                            AS total,
+                        (SELECT COUNT(*) FROM workflow_status WHERE status IN :active_a)
+                            AS in_flight,
+                        (SELECT COUNT(*) FROM workflow_status WHERE status = 'ENQUEUED')
+                            AS enqueued,
+                        (SELECT COUNT(*) FROM workflow_status
+                            WHERE status IN :error_a
+                            AND COALESCE(started_at_epoch_ms, created_at) >= :since_ms)
+                            AS failed_recent,
+                        (SELECT COUNT(*) FROM notifications WHERE consumed = 0)
+                            AS pending_notifications,
+                        (SELECT COUNT(*) FROM workflow_schedules WHERE status = 'ACTIVE')
+                            AS active_schedules
+                    """
+                ).bindparams(_expanding("active_a"), _expanding("error_a"))
+                row = (
+                    await conn.execute(
+                        stmt,
+                        {
+                            "active_a": list(ACTIVE_STATUSES),
+                            "error_a": list(ERROR_STATUSES),
+                            "since_ms": since_ms,
+                        },
+                    )
+                ).fetchone()
+        except OperationalError:
+            return _EMPTY_STATS
+        if row is None:
+            return _EMPTY_STATS
+        return StatsRow(
+            total=row.total,
+            in_flight=row.in_flight,
+            enqueued=row.enqueued,
+            failed_recent=row.failed_recent,
+            pending_notifications=row.pending_notifications,
+            active_schedules=row.active_schedules,
+        )
+
+    async def get_throughput(
+        self, since_ms: int, until_ms: int, bucket: Literal["hour", "day"]
+    ) -> list[ThroughputRow]:
+        bucket_ms = _BUCKET_MS[bucket]
+        try:
+            async with self.engine.connect() as conn:
+                rows = (
+                    await conn.execute(
+                        text(
+                            "SELECT created_at, status FROM workflow_status "
+                            "WHERE created_at >= :s AND created_at <= :u"
+                        ),
+                        {"s": since_ms, "u": until_ms},
+                    )
+                ).fetchall()
+        except OperationalError:
+            return []
+
+        # Bucket the rows in Python — keeps the SQL portable and skips the
+        # generate_series / date_trunc apparatus we'd otherwise need.
+        counts: dict[int, dict[str, int]] = defaultdict(
+            lambda: {"succeeded": 0, "errored": 0, "running": 0}
+        )
+        for r in rows:
+            b = (r.created_at // bucket_ms) * bucket_ms
+            if r.status == "SUCCESS":
+                counts[b]["succeeded"] += 1
+            elif r.status in ERROR_STATUSES:
+                counts[b]["errored"] += 1
+            elif r.status in ACTIVE_STATUSES:
+                counts[b]["running"] += 1
+
+        # Emit a contiguous bucket sequence (zero-filling empties) so the
+        # client gets a complete time axis even on quiet windows.
+        first = (since_ms // bucket_ms) * bucket_ms
+        last = (until_ms // bucket_ms) * bucket_ms
+        result: list[ThroughputRow] = []
+        b = first
+        while b <= last:
+            c = counts.get(b, {"succeeded": 0, "errored": 0, "running": 0})
+            result.append(
+                ThroughputRow(
+                    ts=datetime.fromtimestamp(b / 1000, tz=UTC),
+                    succeeded=c["succeeded"],
+                    errored=c["errored"],
+                    running=c["running"],
+                )
+            )
+            b += bucket_ms
+        return result
+
+    async def list_schedules(self) -> list[ScheduleRow]:
+        try:
+            async with self.engine.connect() as conn:
+                rows = (
+                    await conn.execute(
+                        text(
+                            """
+                            SELECT
+                                schedule_id, schedule_name, workflow_name, workflow_class_name,
+                                schedule, status, last_fired_at, automatic_backfill,
+                                cron_timezone, queue_name
+                            FROM workflow_schedules
+                            ORDER BY schedule_name ASC
+                            """
+                        )
+                    )
+                ).fetchall()
+        except OperationalError:
+            return []
+        return [
+            ScheduleRow(
+                schedule_id=r.schedule_id,
+                schedule_name=r.schedule_name,
+                workflow_name=r.workflow_name,
+                workflow_class_name=r.workflow_class_name,
+                schedule=r.schedule,
+                status=r.status,
+                last_fired_at=r.last_fired_at,
+                automatic_backfill=bool(r.automatic_backfill),
+                cron_timezone=r.cron_timezone,
+                queue_name=r.queue_name,
+            )
+            for r in rows
+        ]
+
+    async def list_notifications(self, filters: NotificationFilters) -> NotificationsRows:
+        conditions: list[str] = []
+        params: dict[str, object] = {"limit": filters.limit}
+        if filters.consumed is not None:
+            conditions.append("consumed = :consumed")
+            # SQLite booleans are 0/1; pass through the int form so the
+            # comparison works regardless of dialect-level coercion.
+            params["consumed"] = 1 if filters.consumed else 0
+        if filters.destination_uuid:
+            conditions.append("destination_uuid = :destination_uuid")
+            params["destination_uuid"] = filters.destination_uuid
+        if filters.topic:
+            conditions.append("topic = :topic")
+            params["topic"] = filters.topic
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        sql = f"""
+            SELECT message_uuid, destination_uuid, topic, consumed, created_at_epoch_ms,
+                   message, serialization
+            FROM notifications
+            {where}
+            ORDER BY created_at_epoch_ms DESC
+            LIMIT :limit
+        """
+        try:
+            async with self.engine.connect() as conn:
+                rows = (await conn.execute(text(sql), params)).fetchall()
+                destination_ids = list({r.destination_uuid for r in rows})
+                ancestor_rows = []
+                if destination_ids:
+                    ancestors_stmt = text(
+                        """
+                        WITH RECURSIVE up AS (
+                            SELECT
+                                ws.workflow_uuid AS seed_id,
+                                ws.workflow_uuid,
+                                ws.parent_workflow_id,
+                                ws.name,
+                                ws.status,
+                                0 AS lvl
+                            FROM workflow_status ws
+                            WHERE ws.workflow_uuid IN :destination_ids
+
+                            UNION ALL
+
+                            SELECT
+                                u.seed_id,
+                                ws.workflow_uuid,
+                                ws.parent_workflow_id,
+                                ws.name,
+                                ws.status,
+                                u.lvl + 1
+                            FROM workflow_status ws
+                            JOIN up u ON ws.workflow_uuid = u.parent_workflow_id
+                        )
+                        SELECT seed_id, workflow_uuid, name, status, lvl
+                        FROM up
+                        ORDER BY seed_id, lvl DESC
+                        """
+                    ).bindparams(_expanding("destination_ids"))
+                    ancestor_rows = (
+                        await conn.execute(ancestors_stmt, {"destination_ids": destination_ids})
+                    ).fetchall()
+        except OperationalError:
+            return NotificationsRows(notifications=[], ancestors=[])
+
+        notifications = [
+            NotificationRow(
+                message_uuid=r.message_uuid,
+                destination_uuid=r.destination_uuid,
+                topic=r.topic,
+                consumed=bool(r.consumed),
+                created_at_epoch_ms=r.created_at_epoch_ms,
+                message=r.message,
+                serialization=r.serialization,
+            )
+            for r in rows
+        ]
+        ancestors = [
+            AncestorRow(
+                seed_id=ar.seed_id,
+                workflow_uuid=ar.workflow_uuid,
+                name=ar.name,
+                status=ar.status,
+                lvl=ar.lvl,
+            )
+            for ar in ancestor_rows
+        ]
+        return NotificationsRows(notifications=notifications, ancestors=ancestors)
+
+
+def _dfs_grouped(rows) -> list[WorkflowListRow]:
+    """Convert flat (parent_id, root_uuid, root_updated_at, depth, …) rows
+    from the recursive grouped query into a DFS-ordered list — same layout
+    the Postgres query emits via `ORDER BY root_updated_at DESC, sort_path`."""
+    # Group by root, sort roots by root_updated_at DESC.
+    by_root: dict[str, dict[str, object]] = {}
+    for r in rows:
+        rec = by_root.setdefault(
+            r.root_uuid,
+            {"root_updated_at": r.root_updated_at, "rows": []},
+        )
+        rec["rows"].append(r)
+    sorted_roots = sorted(
+        by_root.values(),
+        key=lambda v: v["root_updated_at"],
+        reverse=True,
+    )
+
+    out: list[WorkflowListRow] = []
+    for rec in sorted_roots:
+        out.extend(_dfs_in_group(rec["rows"]))
+    return out
+
+
+def _dfs_in_group(rows) -> list[WorkflowListRow]:
+    """DFS over a single root's subtree, ordered by started_ms within
+    siblings to match the Postgres `sort_path` layout."""
+    children: dict[str | None, list] = defaultdict(list)
+    self_row: dict[str, object] = {}
+    root_uuid = None
+    for r in rows:
+        self_row[r.workflow_uuid] = r
+        if r.depth == 0:
+            root_uuid = r.workflow_uuid
+        else:
+            children[r.parent_workflow_id].append(r)
+    for kids in children.values():
+        kids.sort(key=lambda c: c.started_ms)
+
+    if root_uuid is None:
+        return []
+
+    out: list[WorkflowListRow] = []
+    stack = [self_row[root_uuid]]
+    while stack:
+        cur = stack.pop()
+        out.append(_to_workflow_list_row(cur))
+        kids = children.get(cur.workflow_uuid, [])
+        # push reversed so leftmost child is processed first
+        for k in reversed(kids):
+            stack.append(k)
+    return out
+
+
+def _to_workflow_list_row(r) -> WorkflowListRow:
+    return WorkflowListRow(
+        workflow_uuid=r.workflow_uuid,
+        parent_workflow_id=r.parent_workflow_id,
+        name=r.name,
+        status=r.status,
+        queue_name=r.queue_name,
+        executor_id=r.executor_id,
+        priority=r.priority,
+        started_ms=r.started_ms,
+        updated_ms=r.updated_ms,
+        depth=r.depth,
+        op_count=r.op_count,
+    )
+
+
+def _dfs_family(rows) -> list:
+    """DFS the workflow_detail family rows by started_ms within siblings.
+    Returns the rows themselves (not yet mapped to dataclasses) so the caller
+    can build `WorkflowFamilyRow`s and pluck `family_ids` in one pass."""
+    if not rows:
+        return []
+    children: dict[str | None, list] = defaultdict(list)
+    by_uuid: dict[str, object] = {}
+    root = None
+    for r in rows:
+        by_uuid[r.workflow_uuid] = r
+        if r.depth == 0:
+            root = r
+        else:
+            children[r.parent_workflow_id].append(r)
+    for kids in children.values():
+        kids.sort(key=lambda c: c.started_ms)
+
+    if root is None:
+        return []
+    out = []
+    stack = [root]
+    while stack:
+        cur = stack.pop()
+        out.append(cur)
+        for k in reversed(children.get(cur.workflow_uuid, [])):
+            stack.append(k)
+    return out

--- a/packages/server/dbos_argus/main.py
+++ b/packages/server/dbos_argus/main.py
@@ -9,19 +9,19 @@ from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
-from sqlalchemy import text
-from sqlalchemy.exc import ProgrammingError, SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError
 
 from . import __version__
-from .db import engine
+from .db import db
+from .db.rows import (
+    NotificationFilters,
+    StepRow,
+    WorkflowFilters,
+)
 from .decoding import decode_dbos_value
 from .schema_dump import load_full_dump
 from .settings import settings
 from .sql_diagnostics import inspect_dbos_schema
-from .workflow_status import (
-    ACTIVE_STATUSES_SQL,
-    ERROR_STATUSES_SQL,
-)
 
 logging.basicConfig(level=settings.log_level)
 logger = logging.getLogger("dbos_argus")
@@ -66,15 +66,14 @@ async def healthz() -> dict[str, str]:
     db_up = True
     db_error: str | None = None
     try:
-        async with engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
+        await db.healthcheck()
     except Exception as e:
         db_up = False
         db_error = str(e)
     body: dict[str, str] = {
         "status": "ok" if db_up else "degraded",
         "database": "up" if db_up else "down",
-        "database_url": engine.url.render_as_string(hide_password=True),
+        "database_url": db.display_url,
     }
     if db_error is not None:
         body["database_error"] = db_error
@@ -111,8 +110,7 @@ class SqlDiagnostics(BaseModel):
 @app.get("/api/sql-diagnostics")
 async def get_sql_diagnostics() -> SqlDiagnostics:
     try:
-        async with engine.connect() as conn:
-            issues = await inspect_dbos_schema(conn)
+        issues = await inspect_dbos_schema(db)
     except SQLAlchemyError as e:
         raise HTTPException(status_code=503, detail="database diagnostics unavailable") from e
     return SqlDiagnostics(
@@ -148,178 +146,6 @@ class WorkflowListItem(BaseModel):
     operation_count: int
 
 
-# In grouped mode, filters apply to the `roots` CTE only — matching roots come
-# along with their entire descendant tree. Each row's sort_path is the
-# accumulated started_ms from root down to itself — Postgres array ordering
-# then yields a DFS traversal with children sitting directly under their parent.
-#
-# In flat mode, filters apply to all workflows; no recursion, ordered by
-# started_at DESC.
-def _build_workflow_sql(grouped: bool, filters: dict[str, object]) -> tuple[str, dict[str, object]]:
-    params: dict[str, object] = {"limit": filters["limit"]}
-    # Conditions that scope what counts as a "root" in grouped mode (and match
-    # rows directly in flat mode). `q` is handled separately because in grouped
-    # mode we want it to match anywhere in the tree, not just at the root.
-    root_conditions: list[str] = []
-
-    if filters.get("started_after") is not None:
-        root_conditions.append("COALESCE(started_at_epoch_ms, created_at) >= :started_after_ms")
-        params["started_after_ms"] = filters["started_after"]
-    if filters.get("started_before") is not None:
-        root_conditions.append("COALESCE(started_at_epoch_ms, created_at) <= :started_before_ms")
-        params["started_before_ms"] = filters["started_before"]
-    if filters.get("statuses"):
-        root_conditions.append("status = ANY(:statuses)")
-        params["statuses"] = filters["statuses"]
-    else:
-        # ENQUEUED runs are surfaced in the workflow-list page's pinned strip,
-        # so the main list defaults to hiding them. An explicit `status` filter
-        # opts back in (the strip uses ?status=ENQUEUED).
-        root_conditions.append("status <> 'ENQUEUED'")
-    if filters.get("queue_name"):
-        root_conditions.append("queue_name = :queue_name")
-        params["queue_name"] = filters["queue_name"]
-    # Scheduled workflow runs use the deterministic id `sched-<schedule_name>-<isoformat>`
-    # (or `sched-<func_name>-<isoformat>` from the deprecated decorator path). DBOS does
-    # not record an explicit "is scheduled" flag on workflow_status, so filtering by id
-    # prefix is the canonical detection — see dbos/_scheduler.py:171.
-    if filters.get("hide_scheduled"):
-        root_conditions.append("workflow_uuid NOT LIKE 'sched-%'")
-
-    has_q = bool(filters.get("q"))
-    if has_q:
-        params["q_pat"] = f"%{filters['q']}%"
-
-    where_extra = (" AND " + " AND ".join(root_conditions)) if root_conditions else ""
-
-    # Operation counts come from a single GROUP BY scoped to the workflow_uuids
-    # we're returning — much cheaper than N+1 correlated subqueries on large
-    # operation_outputs tables.
-    if grouped:
-        # In grouped mode `q` matches at any depth: find any workflow whose
-        # uuid/name matches, walk up parent_workflow_id to find its root, then
-        # include that root's full subtree below. Without this, searching for
-        # a child name (e.g. "dispatch") would miss roots whose own name
-        # doesn't contain the term.
-        if has_q:
-            match_ctes = """
-                upward AS (
-                    SELECT workflow_uuid, parent_workflow_id
-                    FROM dbos.workflow_status
-                    WHERE workflow_uuid ILIKE :q_pat OR name ILIKE :q_pat
-                    UNION
-                    SELECT ws.workflow_uuid, ws.parent_workflow_id
-                    FROM dbos.workflow_status ws
-                    JOIN upward u ON u.parent_workflow_id = ws.workflow_uuid
-                ),
-                matched_roots AS (
-                    SELECT DISTINCT workflow_uuid
-                    FROM upward
-                    WHERE parent_workflow_id IS NULL
-                ),
-            """
-            match_filter = " AND workflow_uuid IN (SELECT workflow_uuid FROM matched_roots)"
-        else:
-            match_ctes = ""
-            match_filter = ""
-        sql = f"""
-            WITH RECURSIVE
-                {match_ctes}roots AS (
-                    SELECT workflow_uuid, updated_at
-                    FROM dbos.workflow_status
-                    WHERE parent_workflow_id IS NULL{where_extra}{match_filter}
-                    ORDER BY updated_at DESC
-                    LIMIT :limit
-                ),
-                tree AS (
-                    SELECT
-                        ws.workflow_uuid,
-                        ws.parent_workflow_id,
-                        ws.name,
-                        ws.status,
-                        ws.queue_name,
-                        ws.executor_id,
-                        ws.priority,
-                        COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
-                        ws.updated_at AS updated_ms,
-                        0 AS depth,
-                        r.updated_at AS root_updated_at,
-                        ARRAY[COALESCE(ws.started_at_epoch_ms, ws.created_at)] AS sort_path
-                    FROM dbos.workflow_status ws
-                    JOIN roots r ON ws.workflow_uuid = r.workflow_uuid
-
-                    UNION ALL
-
-                    SELECT
-                        c.workflow_uuid,
-                        c.parent_workflow_id,
-                        c.name,
-                        c.status,
-                        c.queue_name,
-                        c.executor_id,
-                        c.priority,
-                        COALESCE(c.started_at_epoch_ms, c.created_at),
-                        c.updated_at,
-                        t.depth + 1,
-                        t.root_updated_at,
-                        t.sort_path || COALESCE(c.started_at_epoch_ms, c.created_at)
-                    FROM dbos.workflow_status c
-                    JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
-                ),
-                op_counts AS (
-                    SELECT workflow_uuid, COUNT(*)::bigint AS op_count
-                    FROM dbos.operation_outputs
-                    WHERE workflow_uuid IN (SELECT workflow_uuid FROM tree)
-                    GROUP BY workflow_uuid
-                )
-            SELECT
-                t.workflow_uuid, t.parent_workflow_id, t.name, t.status,
-                t.queue_name, t.executor_id, t.priority,
-                t.started_ms, t.updated_ms, t.depth,
-                COALESCE(oc.op_count, 0)::bigint AS op_count
-            FROM tree t
-            LEFT JOIN op_counts oc ON oc.workflow_uuid = t.workflow_uuid
-            ORDER BY t.root_updated_at DESC, t.sort_path ASC
-        """
-    else:
-        # Flat mode: each row is independent, so `q` filters rows directly
-        # alongside the other conditions.
-        flat_conditions = list(root_conditions)
-        if has_q:
-            flat_conditions.append("(workflow_uuid ILIKE :q_pat OR name ILIKE :q_pat)")
-        flat_where_extra = (" AND " + " AND ".join(flat_conditions)) if flat_conditions else ""
-        flat_where = f"WHERE 1=1{flat_where_extra}" if flat_where_extra else ""
-        sql = f"""
-            WITH chosen AS (
-                SELECT
-                    workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
-                    priority,
-                    COALESCE(started_at_epoch_ms, created_at) AS started_ms,
-                    updated_at AS updated_ms
-                FROM dbos.workflow_status
-                {flat_where}
-                ORDER BY COALESCE(started_at_epoch_ms, created_at) DESC
-                LIMIT :limit
-            ),
-            op_counts AS (
-                SELECT workflow_uuid, COUNT(*)::bigint AS op_count
-                FROM dbos.operation_outputs
-                WHERE workflow_uuid IN (SELECT workflow_uuid FROM chosen)
-                GROUP BY workflow_uuid
-            )
-            SELECT
-                c.workflow_uuid, c.parent_workflow_id, c.name, c.status,
-                c.queue_name, c.executor_id, c.priority,
-                c.started_ms, c.updated_ms,
-                0 AS depth,
-                COALESCE(oc.op_count, 0)::bigint AS op_count
-            FROM chosen c
-            LEFT JOIN op_counts oc ON oc.workflow_uuid = c.workflow_uuid
-            ORDER BY c.started_ms DESC
-        """
-    return sql, params
-
-
 @app.get("/api/workflows")
 async def list_workflows(
     limit: int = Query(default=50, ge=1, le=200),
@@ -331,23 +157,17 @@ async def list_workflows(
     grouped: bool = True,
     hide_scheduled: bool = False,
 ) -> list[WorkflowListItem]:
-    filters: dict[str, object] = {
-        "limit": limit,
-        "q": q.strip() if q else None,
-        "started_after": int(started_after.timestamp() * 1000) if started_after else None,
-        "started_before": int(started_before.timestamp() * 1000) if started_before else None,
-        "statuses": status if status else None,
-        "queue_name": queue_name,
-        "hide_scheduled": hide_scheduled,
-    }
-    sql, params = _build_workflow_sql(grouped, filters)
-    try:
-        async with engine.connect() as conn:
-            result = await conn.execute(text(sql), params)
-            rows = result.fetchall()
-    except ProgrammingError:
-        # dbos schema hasn't been created yet — no app has connected.
-        return []
+    filters = WorkflowFilters(
+        limit=limit,
+        q=q.strip() if q else None,
+        started_after_ms=int(started_after.timestamp() * 1000) if started_after else None,
+        started_before_ms=int(started_before.timestamp() * 1000) if started_before else None,
+        statuses=status if status else None,
+        queue_name=queue_name,
+        hide_scheduled=hide_scheduled,
+        grouped=grouped,
+    )
+    rows = await db.list_workflows(filters)
     return [
         WorkflowListItem(
             workflow_id=r.workflow_uuid,
@@ -486,18 +306,18 @@ class StepResult(BaseModel):
 # the row's `started_at` gives the originally requested duration in ms,
 # independent of how long the sleep actually elapsed in wall time. Returns
 # None for non-sleep rows or when the value isn't parseable as a float.
-def _sleep_requested_ms(
-    function_name: str | None,
-    sleep_output_raw: str | None,
-    started_at_epoch_ms: int | None,
-) -> int | None:
-    if function_name != "DBOS.sleep" or not sleep_output_raw or started_at_epoch_ms is None:
+def _sleep_requested_ms(step: StepRow) -> int | None:
+    if (
+        step.function_name != "DBOS.sleep"
+        or not step.sleep_output_raw
+        or step.started_at_epoch_ms is None
+    ):
         return None
     try:
-        wake_ms = float(sleep_output_raw) * 1000
+        wake_ms = float(step.sleep_output_raw) * 1000
     except (TypeError, ValueError):
         return None
-    requested = round(wake_ms - started_at_epoch_ms)
+    requested = round(wake_ms - step.started_at_epoch_ms)
     return int(requested) if requested >= 0 else None
 
 
@@ -506,133 +326,8 @@ def _sleep_requested_ms(
 # DFS order — matching how the list endpoint groups trees.
 @app.get("/api/workflows/{workflow_id}")
 async def get_workflow(workflow_id: str) -> WorkflowDetail:
-    sql = """
-        WITH RECURSIVE
-            up AS (
-                SELECT workflow_uuid, parent_workflow_id, 0 AS lvl
-                FROM dbos.workflow_status
-                WHERE workflow_uuid = :workflow_id
-
-                UNION ALL
-
-                SELECT ws.workflow_uuid, ws.parent_workflow_id, u.lvl + 1
-                FROM dbos.workflow_status ws
-                JOIN up u ON ws.workflow_uuid = u.parent_workflow_id
-            ),
-            root AS (
-                SELECT workflow_uuid
-                FROM up
-                ORDER BY lvl DESC
-                LIMIT 1
-            ),
-            tree AS (
-                SELECT
-                    ws.workflow_uuid,
-                    ws.parent_workflow_id,
-                    ws.name,
-                    ws.status,
-                    ws.queue_name,
-                    ws.executor_id,
-                    ws.recovery_attempts,
-                    ws.workflow_timeout_ms,
-                    ws.output IS NOT NULL AS has_output,
-                    ws.error IS NOT NULL AS has_error,
-                    COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
-                    ws.updated_at AS updated_ms,
-                    0 AS depth,
-                    ARRAY[COALESCE(ws.started_at_epoch_ms, ws.created_at)] AS sort_path
-                FROM dbos.workflow_status ws
-                JOIN root r ON ws.workflow_uuid = r.workflow_uuid
-
-                UNION ALL
-
-                SELECT
-                    c.workflow_uuid,
-                    c.parent_workflow_id,
-                    c.name,
-                    c.status,
-                    c.queue_name,
-                    c.executor_id,
-                    c.recovery_attempts,
-                    c.workflow_timeout_ms,
-                    c.output IS NOT NULL,
-                    c.error IS NOT NULL,
-                    COALESCE(c.started_at_epoch_ms, c.created_at),
-                    c.updated_at,
-                    t.depth + 1,
-                    t.sort_path || COALESCE(c.started_at_epoch_ms, c.created_at)
-                FROM dbos.workflow_status c
-                JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
-            )
-        SELECT
-            workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
-            recovery_attempts, workflow_timeout_ms,
-            has_output, has_error, started_ms, updated_ms, depth
-        FROM tree
-        ORDER BY sort_path ASC
-    """
-    # Sleep rows store the raw wakeup-time string in `output`. We carry it
-    # through under a dedicated alias so we can compute sleep_requested_ms
-    # in Python without shipping every step's payload to the client.
-    steps_sql = """
-        SELECT
-            o.workflow_uuid,
-            o.function_id,
-            o.function_name,
-            o.output IS NOT NULL AS has_output,
-            o.error IS NOT NULL AS has_error,
-            o.child_workflow_id,
-            o.started_at_epoch_ms,
-            o.completed_at_epoch_ms,
-            seh.key AS event_key,
-            CASE WHEN o.function_name = 'DBOS.sleep' THEN o.output END AS sleep_output_raw
-        FROM dbos.operation_outputs o
-        LEFT JOIN dbos.workflow_events_history seh
-            ON o.function_name = 'DBOS.setEvent'
-            AND seh.workflow_uuid = o.workflow_uuid
-            AND seh.function_id = o.function_id
-        WHERE o.workflow_uuid = ANY(:workflow_ids)
-        ORDER BY o.workflow_uuid, o.function_id ASC
-    """
-
-    # Joins each `dbos.workflow_events` row (current value per key) to every
-    # corresponding `dbos.workflow_events_history` row (one per setEvent call)
-    # and to `dbos.operation_outputs` for the call's completed_at. One row per
-    # historical set; the current value repeats per row and is collapsed in
-    # Python below.
-    events_sql = """
-        SELECT
-            we.workflow_uuid,
-            we.key,
-            we.value AS current_value,
-            we.serialization AS current_serialization,
-            weh.function_id,
-            weh.value AS history_value,
-            weh.serialization AS history_serialization,
-            o.completed_at_epoch_ms
-        FROM dbos.workflow_events we
-        LEFT JOIN dbos.workflow_events_history weh
-            ON weh.workflow_uuid = we.workflow_uuid AND weh.key = we.key
-        LEFT JOIN dbos.operation_outputs o
-            ON o.workflow_uuid = weh.workflow_uuid
-                AND o.function_id = weh.function_id
-        WHERE we.workflow_uuid = ANY(:workflow_ids)
-        ORDER BY we.workflow_uuid, we.key, weh.function_id ASC
-    """
-
-    try:
-        async with engine.connect() as conn:
-            result = await conn.execute(text(sql), {"workflow_id": workflow_id})
-            rows = result.fetchall()
-            family_ids = [r.workflow_uuid for r in rows]
-            steps_result = await conn.execute(text(steps_sql), {"workflow_ids": family_ids})
-            step_rows = steps_result.fetchall()
-            events_result = await conn.execute(text(events_sql), {"workflow_ids": family_ids})
-            event_rows = events_result.fetchall()
-    except ProgrammingError as e:
-        raise HTTPException(status_code=404, detail="workflow not found") from e
-
-    if not rows:
+    detail = await db.get_workflow_detail(workflow_id)
+    if not detail.family:
         raise HTTPException(status_code=404, detail="workflow not found")
 
     family = [
@@ -651,7 +346,7 @@ async def get_workflow(workflow_id: str) -> WorkflowDetail:
             updated_at=datetime.fromtimestamp(r.updated_ms / 1000, tz=UTC),
             depth=r.depth,
         )
-        for r in rows
+        for r in detail.family
     ]
     steps = [
         WorkflowStep(
@@ -672,18 +367,16 @@ async def get_workflow(workflow_id: str) -> WorkflowDetail:
                 else None
             ),
             event_key=s.event_key,
-            sleep_requested_ms=_sleep_requested_ms(
-                s.function_name, s.sleep_output_raw, s.started_at_epoch_ms
-            ),
+            sleep_requested_ms=_sleep_requested_ms(s),
         )
-        for s in step_rows
+        for s in detail.steps
     ]
 
     # Group event rows by (workflow_uuid, key); each group becomes one entry
     # whose `value` is the current row from `workflow_events` and whose
     # `history` is the per-call `workflow_events_history` rows in call order.
     events_by_key: dict[tuple[str, str], WorkflowEventEntry] = {}
-    for e in event_rows:
+    for e in detail.events:
         gk = (e.workflow_uuid, e.key)
         entry = events_by_key.get(gk)
         if entry is None:
@@ -731,16 +424,7 @@ async def get_workflow(workflow_id: str) -> WorkflowDetail:
 # a family contains many workflows with multi-MB pickled outputs.
 @app.get("/api/workflows/{workflow_id}/result")
 async def get_workflow_result(workflow_id: str) -> WorkflowResult:
-    sql = """
-        SELECT output, error, serialization
-        FROM dbos.workflow_status
-        WHERE workflow_uuid = :workflow_id
-    """
-    try:
-        async with engine.connect() as conn:
-            row = (await conn.execute(text(sql), {"workflow_id": workflow_id})).fetchone()
-    except ProgrammingError as e:
-        raise HTTPException(status_code=404, detail="workflow not found") from e
+    row = await db.get_workflow_result(workflow_id)
     if row is None:
         raise HTTPException(status_code=404, detail="workflow not found")
     return WorkflowResult(
@@ -757,21 +441,7 @@ async def get_workflow_result(workflow_id: str) -> WorkflowResult:
 # result endpoint — same lazy-load pattern, indexed by (workflow_uuid, function_id).
 @app.get("/api/workflows/{workflow_id}/steps/{function_id}/result")
 async def get_step_result(workflow_id: str, function_id: int) -> StepResult:
-    sql = """
-        SELECT output, error, serialization
-        FROM dbos.operation_outputs
-        WHERE workflow_uuid = :workflow_id AND function_id = :function_id
-    """
-    try:
-        async with engine.connect() as conn:
-            row = (
-                await conn.execute(
-                    text(sql),
-                    {"workflow_id": workflow_id, "function_id": function_id},
-                )
-            ).fetchone()
-    except ProgrammingError as e:
-        raise HTTPException(status_code=404, detail="step not found") from e
+    row = await db.get_step_result(workflow_id, function_id)
     if row is None:
         raise HTTPException(status_code=404, detail="step not found")
     return StepResult(
@@ -794,45 +464,10 @@ class DashboardStats(BaseModel):
     active_schedules: int
 
 
-# All-zero rollup returned when the dbos schema doesn't exist yet — keeps the
-# overview page rendering even before any DBOS app has connected.
-_EMPTY_STATS = DashboardStats(
-    total=0,
-    in_flight=0,
-    enqueued=0,
-    failed_recent=0,
-    pending_notifications=0,
-    active_schedules=0,
-)
-
-
 @app.get("/api/stats")
 async def get_stats() -> DashboardStats:
-    # Status literals come from `workflow_status.py` — single source of truth
-    # mirroring `dbos.WorkflowStatusString`.
-    sql = f"""
-        SELECT
-            (SELECT COUNT(*) FROM dbos.workflow_status) AS total,
-            (SELECT COUNT(*) FROM dbos.workflow_status
-                WHERE status IN {ACTIVE_STATUSES_SQL}) AS in_flight,
-            (SELECT COUNT(*) FROM dbos.workflow_status
-                WHERE status = 'ENQUEUED') AS enqueued,
-            (SELECT COUNT(*) FROM dbos.workflow_status
-                WHERE status IN {ERROR_STATUSES_SQL}
-                AND COALESCE(started_at_epoch_ms, created_at) >= :since_ms) AS failed_recent,
-            (SELECT COUNT(*) FROM dbos.notifications
-                WHERE consumed = false) AS pending_notifications,
-            (SELECT COUNT(*) FROM dbos.workflow_schedules
-                WHERE status = 'ACTIVE') AS active_schedules
-    """
     since_ms = int(datetime.now(UTC).timestamp() * 1000) - 86_400_000
-    try:
-        async with engine.connect() as conn:
-            row = (await conn.execute(text(sql), {"since_ms": since_ms})).fetchone()
-    except ProgrammingError:
-        return _EMPTY_STATS
-    if row is None:
-        return _EMPTY_STATS
+    row = await db.get_stats(since_ms)
     return DashboardStats(
         total=row.total,
         in_flight=row.in_flight,
@@ -850,9 +485,10 @@ class ThroughputBucket(BaseModel):
     running: int
 
 
-# Range → (date_trunc unit, lookback ms). The unit is interpolated directly
-# into SQL, so the set must stay closed to these literals.
-_THROUGHPUT_RANGES: dict[str, tuple[str, int]] = {
+# Range → (bucket unit, lookback ms). The unit is interpolated directly into
+# adapter SQL via a closed mapping, so the set must stay closed to these
+# literals.
+_THROUGHPUT_RANGES: dict[str, tuple[Literal["hour", "day"], int]] = {
     "24h": ("hour", 24 * 3_600_000),
     "7d": ("day", 7 * 86_400_000),
     "30d": ("day", 30 * 86_400_000),
@@ -866,45 +502,7 @@ async def get_throughput(
     bucket, lookback_ms = _THROUGHPUT_RANGES[range]
     until_ms = int(datetime.now(UTC).timestamp() * 1000)
     since_ms = until_ms - lookback_ms
-    # Bucket unit comes from a closed literal set above — safe to interpolate.
-    sql = f"""
-        WITH params AS (
-            SELECT
-                CAST(:since_ms AS bigint) AS since_ms,
-                CAST(:until_ms AS bigint) AS until_ms
-        ),
-        buckets AS (
-            SELECT generate_series(
-                date_trunc('{bucket}', to_timestamp(p.since_ms / 1000.0)),
-                date_trunc('{bucket}', to_timestamp(p.until_ms / 1000.0)),
-                '1 {bucket}'::interval
-            ) AS ts
-            FROM params p
-        ),
-        events AS (
-            SELECT
-                date_trunc('{bucket}', to_timestamp(ws.created_at / 1000.0)) AS ts,
-                ws.status
-            FROM dbos.workflow_status ws, params p
-            WHERE ws.created_at >= p.since_ms AND ws.created_at <= p.until_ms
-        )
-        SELECT
-            b.ts AS ts,
-            COUNT(e.*) FILTER (WHERE e.status = 'SUCCESS') AS succeeded,
-            COUNT(e.*) FILTER (WHERE e.status IN {ERROR_STATUSES_SQL}) AS errored,
-            COUNT(e.*) FILTER (WHERE e.status IN {ACTIVE_STATUSES_SQL}) AS running
-        FROM buckets b
-        LEFT JOIN events e ON e.ts = b.ts
-        GROUP BY b.ts
-        ORDER BY b.ts ASC
-    """
-    try:
-        async with engine.connect() as conn:
-            rows = (
-                await conn.execute(text(sql), {"since_ms": since_ms, "until_ms": until_ms})
-            ).fetchall()
-    except ProgrammingError:
-        return []
+    rows = await db.get_throughput(since_ms=since_ms, until_ms=until_ms, bucket=bucket)
     return [
         ThroughputBucket(
             ts=r.ts,
@@ -931,19 +529,7 @@ class WorkflowSchedule(BaseModel):
 
 @app.get("/api/schedules")
 async def list_schedules() -> list[WorkflowSchedule]:
-    sql = """
-        SELECT
-            schedule_id, schedule_name, workflow_name, workflow_class_name,
-            schedule, status, last_fired_at, automatic_backfill,
-            cron_timezone, queue_name
-        FROM dbos.workflow_schedules
-        ORDER BY schedule_name ASC
-    """
-    try:
-        async with engine.connect() as conn:
-            rows = (await conn.execute(text(sql))).fetchall()
-    except ProgrammingError:
-        return []
+    rows = await db.list_schedules()
     return [
         WorkflowSchedule(
             schedule_id=r.schedule_id,
@@ -989,72 +575,16 @@ async def list_notifications(
     topic: str | None = None,
     limit: int = Query(default=200, ge=1, le=500),
 ) -> list[NotificationItem]:
-    conditions: list[str] = []
-    params: dict[str, object] = {"limit": limit}
-    if consumed is not None:
-        conditions.append("consumed = :consumed")
-        params["consumed"] = consumed
-    if destination_uuid:
-        conditions.append("destination_uuid = :destination_uuid")
-        params["destination_uuid"] = destination_uuid
-    if topic:
-        conditions.append("topic = :topic")
-        params["topic"] = topic
-    where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
-    sql = f"""
-        SELECT message_uuid, destination_uuid, topic, consumed, created_at_epoch_ms,
-               message, serialization
-        FROM dbos.notifications
-        {where}
-        ORDER BY created_at_epoch_ms DESC
-        LIMIT :limit
-    """
-    # Walks parent_workflow_id from each destination up to the topmost
-    # ancestor in one set-based recursive CTE. Tracks the seed destination so
-    # results can be grouped per-notification client-side.
-    ancestors_sql = """
-        WITH RECURSIVE up AS (
-            SELECT
-                ws.workflow_uuid AS seed_id,
-                ws.workflow_uuid,
-                ws.parent_workflow_id,
-                ws.name,
-                ws.status,
-                0 AS lvl
-            FROM dbos.workflow_status ws
-            WHERE ws.workflow_uuid = ANY(:destination_ids)
-
-            UNION ALL
-
-            SELECT
-                u.seed_id,
-                ws.workflow_uuid,
-                ws.parent_workflow_id,
-                ws.name,
-                ws.status,
-                u.lvl + 1
-            FROM dbos.workflow_status ws
-            JOIN up u ON ws.workflow_uuid = u.parent_workflow_id
+    result = await db.list_notifications(
+        NotificationFilters(
+            limit=limit,
+            consumed=consumed,
+            destination_uuid=destination_uuid,
+            topic=topic,
         )
-        SELECT seed_id, workflow_uuid, name, status, lvl
-        FROM up
-        ORDER BY seed_id, lvl DESC
-    """
-    try:
-        async with engine.connect() as conn:
-            rows = (await conn.execute(text(sql), params)).fetchall()
-            destination_ids = list({r.destination_uuid for r in rows})
-            ancestor_rows = (
-                (
-                    await conn.execute(text(ancestors_sql), {"destination_ids": destination_ids})
-                ).fetchall()
-                if destination_ids
-                else []
-            )
-    except ProgrammingError:
-        return []
+    )
     ancestors_by_seed: dict[str, list[WorkflowAncestor]] = {}
-    for ar in ancestor_rows:
+    for ar in result.ancestors:
         ancestors_by_seed.setdefault(ar.seed_id, []).append(
             WorkflowAncestor(workflow_id=ar.workflow_uuid, name=ar.name, status=ar.status)
         )
@@ -1070,7 +600,7 @@ async def list_notifications(
             message_decoded=decode_dbos_value(r.message, r.serialization),
             destination_ancestors=ancestors_by_seed.get(r.destination_uuid, []),
         )
-        for r in rows
+        for r in result.notifications
     ]
 
 

--- a/packages/server/dbos_argus/schema_diff.py
+++ b/packages/server/dbos_argus/schema_diff.py
@@ -18,11 +18,18 @@ from typing import Literal
 
 from .schema_dump import SchemaDump
 
-# information_schema reports these three as distinct `data_type` values, but
-# they're functionally interchangeable for read-only consumers like Argus.
-# Any other type-equivalence the diff should tolerate goes here.
+# information_schema reports these as distinct `data_type` values, but each
+# group is functionally interchangeable for read-only consumers like Argus.
+#
+# `integer`/`bigint` is included because SQLite's INTEGER storage class is
+# variable-width and indistinguishable at reflection time from a PG `bigint`,
+# while DBOS' SQLite migration declares some `int4` columns (e.g.
+# `operation_outputs.function_id`) as plain `INTEGER`. The runtime cost of
+# treating them as equivalent is nil — Python ints span both ranges — and the
+# CI watchdog still tracks any upstream type changes via the snapshot file.
 _TYPE_SYNONYMS: tuple[frozenset[str], ...] = (
     frozenset({"text", "character varying", "character"}),
+    frozenset({"integer", "bigint"}),
 )
 
 

--- a/packages/server/dbos_argus/settings.py
+++ b/packages/server/dbos_argus/settings.py
@@ -26,13 +26,15 @@ class Settings(BaseSettings):
 
     @field_validator("database_url")
     @classmethod
-    def _force_asyncpg_driver(cls, v: str) -> str:
-        # Argus only ships asyncpg. Rewrite bare postgres URLs so users can
-        # paste a standard libpq connection string without hitting a psycopg2
-        # ImportError from SQLAlchemy's default driver pick.
+    def _force_async_driver(cls, v: str) -> str:
+        # Argus ships asyncpg + aiosqlite. Rewrite bare scheme URLs so users
+        # can paste a standard libpq / DBOS-style connection string without
+        # hitting a sync-driver ImportError from SQLAlchemy's default pick.
         for prefix in ("postgresql://", "postgres://"):
             if v.startswith(prefix):
                 return "postgresql+asyncpg://" + v[len(prefix) :]
+        if v.startswith("sqlite://") and not v.startswith("sqlite+"):
+            return "sqlite+aiosqlite://" + v[len("sqlite://") :]
         return v
 
     def asyncpg_engine_args(self) -> tuple[str, dict[str, Any]]:

--- a/packages/server/dbos_argus/sql_diagnostics.py
+++ b/packages/server/dbos_argus/sql_diagnostics.py
@@ -1,26 +1,27 @@
-"""Schema diagnostics: load the packaged snapshot, dump the live DB, diff them.
+"""Schema diagnostics: load the packaged snapshot, reflect the live DB through
+the adapter, diff them.
 
-The actual machinery is split between `schema_dump` (extract a SchemaDump from
-either a JSON snapshot or a live AsyncConnection) and `schema_diff` (a generic
-dump-vs-dump comparator). This module is the wiring the FastAPI endpoint calls.
+The actual machinery is split between `schema_dump` (load the JSON snapshot
+into a `SchemaDump`), the adapter's `reflect_schema()` (per-dialect live
+reflection), and `schema_diff` (a generic dump-vs-dump comparator). This
+module is the wiring the FastAPI endpoint calls.
 
-The packaged snapshot in `data/dbos_schema.json` is the *full* DBOS schema with
-per-column `argus: true|false` markers. For runtime diagnostics we filter to
-the argus-marked subset before diffing against the live DB; the unmarked
+The packaged snapshot in `data/dbos_schema.json` is the *full* DBOS schema
+with per-column `argus: true|false` markers. For runtime diagnostics we filter
+to the argus-marked subset before diffing against the live DB; the unmarked
 columns are tracked by the CI watchdog only.
 """
 
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import AsyncConnection
-
+from .db.base import ArgusDB
 from .schema_diff import SchemaIssue, diff_schemas
-from .schema_dump import argus_only, dump_live_schema, load_full_dump
+from .schema_dump import argus_only, load_full_dump
 
 __all__ = ["SchemaIssue", "inspect_dbos_schema"]
 
 
-async def inspect_dbos_schema(conn: AsyncConnection) -> list[SchemaIssue]:
+async def inspect_dbos_schema(db: ArgusDB) -> list[SchemaIssue]:
     expected = argus_only(load_full_dump())
-    actual = await dump_live_schema(conn, schema=expected.schema)
+    actual = await db.reflect_schema(schema=expected.schema)
     return diff_schemas(expected, actual)

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "uvicorn[standard]>=0.32.0",
   "sqlalchemy[asyncio]>=2.0.35",
   "asyncpg>=0.29.0",
+  "aiosqlite>=0.20.0",
   "pydantic>=2.9.0",
   "pydantic-settings>=2.6.0",
   "bcrypt>=4.2.0",

--- a/packages/server/tests/integration/conftest.py
+++ b/packages/server/tests/integration/conftest.py
@@ -1,0 +1,294 @@
+"""Integration-test fixtures for the `ArgusDB` adapters.
+
+CI runs this suite once per backend by setting `ARGUS_TEST_DATABASE_URL`
+to a Postgres or SQLite URL; locally the suite falls back to a sqlite
+tempfile so it works offline.
+
+The fixture bootstraps the DBOS system schema using DBOS's own migration
+SQL (`dbos._migration`) — same authority that creates the schema in a
+real DBOS app — then inserts a small but representative seed:
+
+    wf-root (PENDING)
+    ├── wf-child-success (SUCCESS)              ← has output, one event, three steps
+    │   └── wf-grandchild-error (ERROR)         ← has error
+    └── wf-child-pending (PENDING)              ← has one pending notification
+
+…plus one workflow_schedule. That's enough to exercise every endpoint
+shape (DFS family, status filters, search, op counts, events,
+notifications + ancestor chain, schedules, stats, throughput) without
+each test having to assemble its own data.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from dbos_argus.db.base import ArgusDB
+from dbos_argus.db.postgres import PostgresArgusDB
+from dbos_argus.db.sqlite import SqliteArgusDB
+from dbos_argus.settings import Settings
+from sqlalchemy import create_engine, text
+
+# Tables the DBOS schema owns. Listed explicitly (rather than introspected)
+# so a missing-table bug in the adapter can't hide a half-cleaned fixture.
+_DBOS_TABLES = (
+    "workflow_events_history",
+    "workflow_events",
+    "workflow_schedules",
+    "notifications",
+    "streams",
+    "operation_outputs",
+    "workflow_status",
+    "application_versions",
+    "dbos_migrations",
+)
+
+
+def _is_sqlite(url: str) -> bool:
+    return url.startswith("sqlite")
+
+
+def _to_sync_url(async_url: str) -> str:
+    """Async drivers can't run multi-statement migrations cleanly. Map each
+    async URL to a sync sibling whose driver we already have installed
+    (psycopg / pysqlite)."""
+    if async_url.startswith("sqlite+aiosqlite://"):
+        return "sqlite://" + async_url[len("sqlite+aiosqlite://") :]
+    if async_url.startswith("postgresql+asyncpg://"):
+        return "postgresql+psycopg://" + async_url[len("postgresql+asyncpg://") :]
+    return async_url
+
+
+def _bootstrap_postgres(sync_url: str) -> None:
+    # Use DBOS' own helpers — they handle the migration-10 PK-already-exists
+    # corner case that the raw migration list does not.
+    from dbos._migration import ensure_dbos_schema, run_dbos_migrations
+
+    eng = create_engine(sync_url)
+    try:
+        ensure_dbos_schema(eng, "dbos")
+        run_dbos_migrations(eng, "dbos", use_listen_notify=False)
+    finally:
+        eng.dispose()
+
+
+def _bootstrap_sqlite(sync_url: str) -> None:
+    from dbos._migration import sqlite_migrations
+
+    eng = create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE IF NOT EXISTS dbos_migrations "
+                    "(version INTEGER NOT NULL PRIMARY KEY)"
+                )
+            )
+            applied = conn.execute(text("SELECT version FROM dbos_migrations")).fetchone()
+            last = applied[0] if applied else 0
+            for i, mig in enumerate(sqlite_migrations, 1):
+                if i <= last:
+                    continue
+                # SQLite drivers run one statement per execute() call.
+                for stmt in (s.strip() for s in mig.split(";") if s.strip()):
+                    conn.execute(text(stmt))
+                if last == 0:
+                    conn.execute(
+                        text("INSERT INTO dbos_migrations (version) VALUES (:v)"),
+                        {"v": i},
+                    )
+                else:
+                    conn.execute(text("UPDATE dbos_migrations SET version = :v"), {"v": i})
+                last = i
+    finally:
+        eng.dispose()
+
+
+def _drop(sync_url: str) -> None:
+    """Reset state between tests — Postgres uses CASCADE on the schema; SQLite
+    drops each table individually since it has no schema namespace."""
+    eng = create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            if _is_sqlite(sync_url):
+                for t in _DBOS_TABLES:
+                    conn.execute(text(f'DROP TABLE IF EXISTS "{t}"'))
+            else:
+                conn.execute(text('DROP SCHEMA IF EXISTS "dbos" CASCADE'))
+    finally:
+        eng.dispose()
+
+
+def _seed(sync_url: str, base_ms: int) -> dict[str, object]:
+    """Insert the canonical fixture tree. Same INSERTs work on both backends —
+    `dbos.` prefix is the only difference, and that's parametrized."""
+    p = "" if _is_sqlite(sync_url) else "dbos."
+    eng = create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            # workflow_status family. created_at is millisecond-offset from
+            # base_ms so tests can assert ordering deterministically.
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {p}workflow_status
+                        (workflow_uuid, status, name, executor_id, created_at, updated_at,
+                         recovery_attempts, started_at_epoch_ms, priority,
+                         parent_workflow_id, output, error, serialization)
+                    VALUES
+                        ('wf-root', 'PENDING', 'root_workflow', 'test',
+                         :t0, :t0, 0, :t0, 0, NULL, NULL, NULL, 'portable_json'),
+                        ('wf-child-success', 'SUCCESS', 'child_a', 'test',
+                         :t1, :t1, 0, :t1, 0, 'wf-root', '"hello"', NULL, 'portable_json'),
+                        ('wf-child-pending', 'PENDING', 'child_b', 'test',
+                         :t2, :t2, 0, :t2, 0, 'wf-root', NULL, NULL, 'portable_json'),
+                        ('wf-grandchild-error', 'ERROR', 'grandchild', 'test',
+                         :t3, :t3, 0, :t3, 0, 'wf-child-success', NULL, '"boom"',
+                         'portable_json')
+                    """
+                ),
+                {
+                    "t0": base_ms,
+                    "t1": base_ms + 100,
+                    "t2": base_ms + 200,
+                    "t3": base_ms + 300,
+                },
+            )
+            # operation_outputs: an audit, a setEvent (joined to events_history
+            # below), a sleep (so sleep_requested_ms gets exercised), and an
+            # error step on the grandchild.
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {p}operation_outputs
+                        (workflow_uuid, function_id, function_name, output, error,
+                         child_workflow_id, started_at_epoch_ms, completed_at_epoch_ms,
+                         serialization)
+                    VALUES
+                        ('wf-child-success', 1, 'audit', '"audited"', NULL, NULL,
+                         :t1, :t2, 'portable_json'),
+                        ('wf-child-success', 2, 'DBOS.setEvent', NULL, NULL, NULL,
+                         :t2, :t3, 'portable_json'),
+                        ('wf-child-success', 3, 'DBOS.sleep', :sleep_out, NULL, NULL,
+                         :t3, :t3, 'portable_json'),
+                        ('wf-grandchild-error', 1, 'failing_step', NULL, '"boom"', NULL,
+                         :t1, :t2, 'portable_json')
+                    """
+                ),
+                {
+                    "t1": base_ms + 100,
+                    "t2": base_ms + 200,
+                    "t3": base_ms + 300,
+                    # DBOS.sleep stores wakeup time as a unix-seconds string;
+                    # `_sleep_requested_ms` derives 500ms from this row.
+                    "sleep_out": str((base_ms + 800) / 1000),
+                },
+            )
+            # workflow_events + history (must match function_id=2 above so
+            # the JOIN in get_steps populates `event_key`).
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {p}workflow_events (workflow_uuid, key, value, serialization)
+                    VALUES ('wf-child-success', 'demo', '"hi"', 'portable_json')
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {p}workflow_events_history
+                        (workflow_uuid, function_id, key, value, serialization)
+                    VALUES ('wf-child-success', 2, 'demo', '"hi"', 'portable_json')
+                    """
+                )
+            )
+            # notification: targets wf-child-pending so the ancestor chain
+            # walk has something to walk (child → root).
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {p}notifications
+                        (message_uuid, destination_uuid, topic, message,
+                         created_at_epoch_ms, serialization, consumed)
+                    VALUES ('msg-1', 'wf-child-pending', 'topic-a', '"payload"',
+                            :t, 'portable_json', :consumed)
+                    """
+                ),
+                {"t": base_ms + 50, "consumed": False},
+            )
+            # one ACTIVE schedule
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO {p}workflow_schedules
+                        (schedule_id, schedule_name, workflow_name, workflow_class_name,
+                         schedule, status, context, automatic_backfill)
+                    VALUES ('sched-1', 'demo-schedule', 'demo_wf', NULL,
+                            '*/5 * * * *', 'ACTIVE', '{{}}', :b)
+                    """
+                ),
+                {"b": False},
+            )
+    finally:
+        eng.dispose()
+    return {
+        "root_id": "wf-root",
+        "child_success_id": "wf-child-success",
+        "child_pending_id": "wf-child-pending",
+        "grandchild_error_id": "wf-grandchild-error",
+        "base_ms": base_ms,
+    }
+
+
+@pytest.fixture(scope="session")
+def db_url() -> AsyncIterator[str]:
+    """The async URL the adapter under test connects with."""
+    explicit = os.environ.get("ARGUS_TEST_DATABASE_URL")
+    if explicit:
+        # Normalize to the async driver Argus expects, so CI users can paste
+        # a plain libpq URL.
+        if explicit.startswith("postgresql://") or explicit.startswith("postgres://"):
+            scheme, rest = explicit.split("://", 1)
+            yield f"postgresql+asyncpg://{rest}"
+        elif explicit.startswith("sqlite://") and not explicit.startswith("sqlite+"):
+            yield "sqlite+aiosqlite://" + explicit[len("sqlite://") :]
+        else:
+            yield explicit
+        return
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="argus-it-"))
+    try:
+        yield f"sqlite+aiosqlite:///{tmp_dir / 'argus.sqlite'}"
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _make_adapter(url: str) -> ArgusDB:
+    settings = Settings(database_url=url)
+    return SqliteArgusDB(settings) if _is_sqlite(url) else PostgresArgusDB(settings)
+
+
+@pytest.fixture
+async def populated_db(db_url: str) -> AsyncIterator[tuple[ArgusDB, dict[str, object]]]:
+    """Reset the DBOS schema, run migrations, seed fixture rows, yield a
+    fresh adapter. Disposes the engine on teardown so each test starts
+    with no shared connection state."""
+    sync_url = _to_sync_url(db_url)
+    _drop(sync_url)
+    if _is_sqlite(db_url):
+        _bootstrap_sqlite(sync_url)
+    else:
+        _bootstrap_postgres(sync_url)
+    seed = _seed(sync_url, base_ms=1_700_000_000_000)
+
+    adapter = _make_adapter(db_url)
+    try:
+        yield adapter, seed
+    finally:
+        await adapter.engine.dispose()

--- a/packages/server/tests/integration/test_db_adapter.py
+++ b/packages/server/tests/integration/test_db_adapter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dbos_argus.db.base import ArgusDB
 from dbos_argus.db.rows import NotificationFilters, WorkflowFilters
+from dbos_argus.sql_diagnostics import inspect_dbos_schema
 
 # Type alias for the (adapter, seed) tuple yielded by `populated_db`.
 DB = tuple[ArgusDB, dict[str, object]]
@@ -34,6 +35,19 @@ async def test_reflect_schema_returns_dbos_tables(populated_db: DB) -> None:
         "workflow_events_history",
         "workflow_schedules",
     } <= names
+
+
+async def test_live_schema_matches_pinned_snapshot(populated_db: DB) -> None:
+    """`/api/sql-diagnostics` must report `ok: true` after a fresh DBOS
+    migration on either backend. Effectively asserts that
+    `data/dbos_schema.json` (the single PG-vocabulary snapshot, regenerated
+    daily by the watchdog) covers both the Postgres and SQLite migration
+    outputs. If DBOS ever ships an argus-tracked column to one dialect but
+    not the other, the matrix leg pointing at the affected backend will
+    fail here — surfacing drift the PG-only watchdog can't see."""
+    db, _ = populated_db
+    issues = await inspect_dbos_schema(db)
+    assert issues == [], "schema drift: " + "; ".join(i.detail for i in issues)
 
 
 async def test_list_workflows_grouped_returns_full_tree(populated_db: DB) -> None:

--- a/packages/server/tests/integration/test_db_adapter.py
+++ b/packages/server/tests/integration/test_db_adapter.py
@@ -1,0 +1,188 @@
+"""Adapter-level integration tests run against either backend.
+
+CI parametrizes the backend by setting `ARGUS_TEST_DATABASE_URL` per
+matrix dimension; locally the conftest falls back to a sqlite tempfile.
+Each test only knows about the abstract `ArgusDB` interface and the seed
+fixture — there is no per-dialect branching here.
+"""
+
+from __future__ import annotations
+
+from dbos_argus.db.base import ArgusDB
+from dbos_argus.db.rows import NotificationFilters, WorkflowFilters
+
+# Type alias for the (adapter, seed) tuple yielded by `populated_db`.
+DB = tuple[ArgusDB, dict[str, object]]
+
+
+async def test_healthcheck_succeeds(populated_db: DB) -> None:
+    db, _ = populated_db
+    # Raises on connection failure; absence of exception is the assert.
+    await db.healthcheck()
+
+
+async def test_reflect_schema_returns_dbos_tables(populated_db: DB) -> None:
+    db, _ = populated_db
+    dump = await db.reflect_schema(schema="dbos")
+    names = {t.name for t in dump.tables}
+    # The argus-tracked tables must all be present after migration.
+    assert {
+        "workflow_status",
+        "operation_outputs",
+        "notifications",
+        "workflow_events",
+        "workflow_events_history",
+        "workflow_schedules",
+    } <= names
+
+
+async def test_list_workflows_grouped_returns_full_tree(populated_db: DB) -> None:
+    db, seed = populated_db
+    rows = await db.list_workflows(WorkflowFilters(grouped=True))
+    # Root + 2 children + 1 grandchild — the seed has no ENQUEUED rows so
+    # the default-exclude filter doesn't drop anything.
+    assert len(rows) == 4
+    # Root sits first in DFS order with depth 0.
+    assert rows[0].workflow_uuid == seed["root_id"]
+    assert rows[0].depth == 0
+    # The grandchild's depth should be 2 (root → child_success → grandchild).
+    grandchild = next(r for r in rows if r.workflow_uuid == seed["grandchild_error_id"])
+    assert grandchild.depth == 2
+
+
+async def test_list_workflows_flat_orders_by_started(populated_db: DB) -> None:
+    db, _ = populated_db
+    rows = await db.list_workflows(WorkflowFilters(grouped=False))
+    assert len(rows) == 4
+    # Flat mode: most recent started first.
+    started = [r.started_ms for r in rows]
+    assert started == sorted(started, reverse=True)
+
+
+async def test_list_workflows_status_filter(populated_db: DB) -> None:
+    db, seed = populated_db
+    rows = await db.list_workflows(WorkflowFilters(grouped=False, statuses=["SUCCESS"]))
+    assert [r.workflow_uuid for r in rows] == [seed["child_success_id"]]
+
+
+async def test_list_workflows_q_matches_grandchild(populated_db: DB) -> None:
+    db, seed = populated_db
+    # Flat mode q matches name OR uuid — `grandchild` only appears in the name.
+    rows = await db.list_workflows(WorkflowFilters(grouped=False, q="grandchild"))
+    assert [r.workflow_uuid for r in rows] == [seed["grandchild_error_id"]]
+
+
+async def test_list_workflows_grouped_q_includes_root(populated_db: DB) -> None:
+    db, seed = populated_db
+    # In grouped mode `q` matches at any depth — the grandchild's match must
+    # pull its whole root family into the result, not just the matching row.
+    rows = await db.list_workflows(WorkflowFilters(grouped=True, q="grandchild"))
+    uuids = {r.workflow_uuid for r in rows}
+    assert seed["root_id"] in uuids
+    assert seed["grandchild_error_id"] in uuids
+
+
+async def test_get_workflow_detail_returns_family_steps_events(populated_db: DB) -> None:
+    db, seed = populated_db
+    detail = await db.get_workflow_detail(seed["child_success_id"])
+    # The detail endpoint always expands to the topmost ancestor's whole tree.
+    assert {f.workflow_uuid for f in detail.family} == {
+        seed["root_id"],
+        seed["child_success_id"],
+        seed["child_pending_id"],
+        seed["grandchild_error_id"],
+    }
+    # Steps include the seeded operation_outputs rows.
+    setevent = next(s for s in detail.steps if s.function_name == "DBOS.setEvent")
+    assert setevent.event_key == "demo"  # joined from workflow_events_history
+    sleep = next(s for s in detail.steps if s.function_name == "DBOS.sleep")
+    assert sleep.sleep_output_raw is not None
+    # workflow_events row plus its history row.
+    assert any(e.key == "demo" for e in detail.events)
+
+
+async def test_get_workflow_detail_unknown_returns_empty(populated_db: DB) -> None:
+    db, _ = populated_db
+    detail = await db.get_workflow_detail("does-not-exist")
+    assert detail.family == []
+    assert detail.steps == []
+    assert detail.events == []
+
+
+async def test_get_workflow_result_returns_payload(populated_db: DB) -> None:
+    db, seed = populated_db
+    row = await db.get_workflow_result(seed["child_success_id"])
+    assert row is not None
+    assert row.output == '"hello"'
+    assert row.error is None
+
+
+async def test_get_workflow_result_missing(populated_db: DB) -> None:
+    db, _ = populated_db
+    assert await db.get_workflow_result("nope") is None
+
+
+async def test_get_step_result_returns_payload(populated_db: DB) -> None:
+    db, seed = populated_db
+    row = await db.get_step_result(seed["child_success_id"], 1)
+    assert row is not None
+    assert row.output == '"audited"'
+
+
+async def test_get_step_result_missing(populated_db: DB) -> None:
+    db, _ = populated_db
+    assert await db.get_step_result("wf-root", 9999) is None
+
+
+async def test_get_stats_counts_seed(populated_db: DB) -> None:
+    db, seed = populated_db
+    base_ms: int = int(seed["base_ms"])
+    stats = await db.get_stats(since_ms=base_ms - 86_400_000)
+    assert stats.total == 4
+    assert stats.in_flight == 2  # 2 PENDING
+    assert stats.enqueued == 0
+    assert stats.failed_recent == 1  # the grandchild ERROR within the window
+    assert stats.pending_notifications == 1
+    assert stats.active_schedules == 1
+
+
+async def test_get_throughput_buckets_seed_day(populated_db: DB) -> None:
+    db, seed = populated_db
+    base_ms: int = int(seed["base_ms"])
+    rows = await db.get_throughput(
+        since_ms=base_ms - 86_400_000,
+        until_ms=base_ms + 86_400_000,
+        bucket="day",
+    )
+    # Bucket boundaries differ by dialect calendar mechanics, but the total
+    # of (succeeded + errored + running) across the window must equal the
+    # number of seeded workflows.
+    total = sum(r.succeeded + r.errored + r.running for r in rows)
+    assert total == 4
+
+
+async def test_list_schedules_returns_seeded_schedule(populated_db: DB) -> None:
+    db, _ = populated_db
+    schedules = await db.list_schedules()
+    assert [s.schedule_id for s in schedules] == ["sched-1"]
+    assert schedules[0].status == "ACTIVE"
+
+
+async def test_list_notifications_includes_ancestor_chain(populated_db: DB) -> None:
+    db, seed = populated_db
+    result = await db.list_notifications(NotificationFilters())
+    assert [n.message_uuid for n in result.notifications] == ["msg-1"]
+    assert result.notifications[0].topic == "topic-a"
+    # Ancestor walk: child_pending → root, both rows reported.
+    seed_id = seed["child_pending_id"]
+    chain = [a for a in result.ancestors if a.seed_id == seed_id]
+    chain_uuids = {a.workflow_uuid for a in chain}
+    assert chain_uuids == {seed["root_id"], seed["child_pending_id"]}
+
+
+async def test_list_notifications_consumed_filter(populated_db: DB) -> None:
+    db, _ = populated_db
+    consumed = await db.list_notifications(NotificationFilters(consumed=True))
+    assert consumed.notifications == []
+    pending = await db.list_notifications(NotificationFilters(consumed=False))
+    assert len(pending.notifications) == 1

--- a/packages/server/tests/test_sql_diagnostics.py
+++ b/packages/server/tests/test_sql_diagnostics.py
@@ -35,7 +35,7 @@ def test_diff_reports_missing_table_column_and_type_mismatch() -> None:
         ("workflow_events_history", [("key", "text")]),
     )
     actual = _dump(
-        ("workflow_status", [("workflow_uuid", "text"), ("created_at", "integer")]),
+        ("workflow_status", [("workflow_uuid", "text"), ("created_at", "numeric")]),
         ("notifications", []),
     )
 
@@ -44,10 +44,18 @@ def test_diff_reports_missing_table_column_and_type_mismatch() -> None:
     assert [
         (i.kind, i.table_name, i.column_name, i.expected_type, i.actual_type) for i in issues
     ] == [
-        ("wrong_type", "workflow_status", "created_at", "bigint", "integer"),
+        ("wrong_type", "workflow_status", "created_at", "bigint", "numeric"),
         ("missing_column", "notifications", "consumed", "boolean", None),
         ("missing_table", "workflow_events_history", None, None, None),
     ]
+
+
+def test_diff_treats_integer_and_bigint_as_equivalent() -> None:
+    # SQLite reflection cannot distinguish int4 from int8 columns; the diff
+    # therefore accepts either.
+    expected = _dump(("t", [("c", "integer")]))
+    actual = _dump(("t", [("c", "bigint")]))
+    assert diff_schemas(expected, actual) == []
 
 
 def test_diff_treats_pg_string_synonyms_as_equivalent() -> None:
@@ -102,19 +110,6 @@ def test_load_full_dump_is_self_consistent() -> None:
     assert diff_schemas(argus_only(full), full) == []
 
 
-class _FakeConnectionContext:
-    async def __aenter__(self) -> object:
-        return object()
-
-    async def __aexit__(self, exc_type, exc, tb) -> bool:
-        return False
-
-
-class _FakeEngine:
-    def connect(self) -> _FakeConnectionContext:
-        return _FakeConnectionContext()
-
-
 def test_version_endpoint_includes_tested_dbos_version() -> None:
     with TestClient(app) as client:
         response = client.get("/version")
@@ -127,7 +122,7 @@ def test_version_endpoint_includes_tested_dbos_version() -> None:
 
 
 def test_sql_diagnostics_endpoint_returns_schema_issues(monkeypatch) -> None:
-    async def fake_inspect_dbos_schema(_conn: object) -> list[SchemaIssue]:
+    async def fake_inspect_dbos_schema(_db: object) -> list[SchemaIssue]:
         return [
             SchemaIssue(
                 kind="missing_table",
@@ -139,7 +134,6 @@ def test_sql_diagnostics_endpoint_returns_schema_issues(monkeypatch) -> None:
             )
         ]
 
-    monkeypatch.setattr(main, "engine", _FakeEngine())
     monkeypatch.setattr(main, "inspect_dbos_schema", fake_inspect_dbos_schema)
 
     with TestClient(app) as client:

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,15 @@ members = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +223,7 @@ wheels = [
 name = "dbos-argus"
 source = { editable = "packages/server" }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "click" },
@@ -226,6 +236,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bcrypt", specifier = ">=4.2.0" },
     { name = "click", specifier = ">=8.1.0" },


### PR DESCRIPTION
## Summary

- Split the data layer into an `ArgusDB` adapter with two implementations (`PostgresArgusDB`, `SqliteArgusDB`). `main.py` keeps only Pydantic mapping + decoding.
- Add SQLite support end-to-end. Argus now runs against either `postgresql+asyncpg://` or `sqlite+aiosqlite:///` URLs (and accepts the bare `postgres://` / `sqlite://` forms — `settings.py` rewrites them).
- Add an integration test layer + CI matrix over `{postgres, sqlite}` so both adapters are exercised on every PR.
- Verify the single PG-vocabulary `data/dbos_schema.json` against both backends via a new `test_live_schema_matches_pinned_snapshot` test (no need to ship a second snapshot file).

## Adapter shape

```
packages/server/dbos_argus/db/
  base.py       # ArgusDB ABC
  rows.py       # typed row + filter dataclasses
  postgres.py   # PostgresArgusDB — today's SQL, verbatim
  sqlite.py     # SqliteArgusDB — dialect-specific rewrites
```

`main.py` calls `await db.list_workflows(filters)` etc.; the adapter owns the engine and per-dialect SQL.

## SQLite dialect deltas

- Drop the `dbos.` schema prefix (SQLite has no schema namespace).
- `= ANY(:array)` → `IN :array` with SQLAlchemy expanding bindparams.
- `ILIKE` → `LIKE` (SQLite's default collation is ASCII case-insensitive).
- `ARRAY[…] || x` recursive sort_path → carry `root_uuid`/`depth` through the CTE; DFS sort in Python (`_dfs_grouped`, `_dfs_family`).
- `generate_series` + `date_trunc` + `to_timestamp` + `interval` → bucket throughput in Python via integer division of `created_at`.
- `information_schema` → `sqlite_master` + `pragma_table_info`, with type strings normalized into the snapshot's vocabulary.
- SQLite `INTEGER` is variable-width and indistinguishable from `BIGINT` at reflection time, so `schema_diff` now treats them as synonyms (read-only consumers don't care; the watchdog still tracks upstream type changes via the snapshot).

## Tests + CI

- `packages/server/tests/integration/conftest.py` — bootstraps the DBOS schema using DBOS's own helpers (`dbos._migration.ensure_dbos_schema` / `run_dbos_migrations` / `sqlite_migrations`), seeds a 4-workflow family with steps, events, a notification, and a schedule, yields a fresh `ArgusDB`. Defaults to a sqlite tempfile when `ARGUS_TEST_DATABASE_URL` is unset.
- `packages/server/tests/integration/test_db_adapter.py` — 19 tests against the abstract interface; same battery runs on both backends.
- `ci-python.yml` split into `lint` (once) and `test` (matrix `{sqlite, postgres}`). Postgres service container always provisioned to keep the matrix flat.

## Schema snapshot story

We keep one Postgres-vocabulary `data/dbos_schema.json` rather than shipping a parallel sqlite file. The argus-tracked subset is identical across DBOS dialects (every dialect-specific delta — `event_dispatch_kv`, PL/pgSQL functions, LISTEN/NOTIFY — is write-side and `argus: false`). The new `test_live_schema_matches_pinned_snapshot` runs the same `inspect_dbos_schema()` the `/api/sql-diagnostics` endpoint serves against the live test DB on each matrix leg; if DBOS ever ships an argus-tracked column to one dialect and not the other, the affected leg fails — surfacing drift the PG-only watchdog couldn't see, without us maintaining two snapshots.

## Local validation

- 49/49 passing on `unset ARGUS_TEST_DATABASE_URL` (sqlite tempfile)
- 49/49 passing on `ARGUS_TEST_DATABASE_URL=postgresql+asyncpg://argus:argus@localhost:5432/argus`
- ruff check + format clean
- Live smoke against docker-compose Postgres and a real sqlite seed: every endpoint returns the expected shape (workflow list grouped/flat/q/status, detail family DFS, lazy result endpoints, stats, timeseries bucket alignment, schedules, notifications + ancestor chain, sql-diagnostics)

## Test plan

- [ ] CI matrix passes on `tm/sqlite-adapter` (both `lint`, `test (sqlite)`, `test (postgres)`)
- [ ] No regression on the existing `dbos-schema-watch` workflow