### PR TITLE
Realtime WebSocket layer + SQLite adapter integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Tested against DBOS 2.19.0** — see `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Other DBOS versions may still work; the in-app connection indicator surfaces any schema mismatches.
 
+### Added
+- Realtime (WebSocket) layer at `/ws` replaces per-page polling. One
+  multiplexed socket carries every page's subscriptions; server-side
+  pollers gate heavier snapshots behind a cheap cursor query and shut
+  down when the last subscriber disconnects. Channels: `health`,
+  `stats`, `stats.timeseries`, `workflows`, `workflow`, `schedules`,
+  `notifications` — each emits the same JSON shape as its REST
+  counterpart, which remains authoritative for curl/debug. Cursor
+  queries are implemented per-dialect on `ArgusDB` so the layer works
+  unchanged on both Postgres and SQLite. Configurable via
+  `ARGUS_REALTIME_ENABLED`, `ARGUS_REALTIME_INTERVAL_MS`,
+  `ARGUS_REALTIME_HEALTH_INTERVAL_MS`, and
+  `ARGUS_REALTIME_MAX_SUBS_PER_CONN`.
+- Live workflow detail page: subscribing to `workflow` with `{id}`
+  re-snapshots every tick so steps appear as they complete.
+
+### Changed
+- Connection indicator now reflects WebSocket health (with a 1Hz
+  poll surfacing disconnects as a sticky `fetchError`) instead of
+  per-page `setInterval(5000)` `/healthz` fetches.
+
 ## [0.0.20] - 2026-05-04
 
 > **Tested against DBOS 2.19.0** — see `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Other DBOS versions may still work; the in-app connection indicator surfaces any schema mismatches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ The `/api/sql-diagnostics` endpoint diffs the live schema against `packages/serv
 1. **Argus is read-only.** The server only reads from DBOS Transact's `dbos.*` system tables. New features should stay on the read path unless the project scope explicitly changes.
 2. **The console is a client of the Argus backend, never of Postgres directly.**
 3. **No app-side SDK.** All UI actions are server-mediated. There is no `@dbos-argus/client` package and no WS-app-registry protocol.
+4. **Realtime channels mirror REST shapes and go through `ArgusDB`.** Each channel in `packages/server/dbos_argus/realtime/channels/` lazy-imports a `fetch_*` helper from `main.py` (the same helper the REST route calls) so the two transports never drift. Snapshots and cursors run through `db.<method>()` — no raw SQL in channels — so SQLite + Postgres stay supported in lockstep.
 
 ## Stack notes that matter
 

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -64,6 +64,11 @@
   const HEAD = 5;
   const TAIL = 5;
   const LAYOUT_ANIMATION_MS = 240;
+  // Minimum container size — ELK collapses empty containers to ~0, which hides
+  // the workflow header (name + id). Floor the layout output so a workflow
+  // with zero steps yet still renders a proper container box.
+  const CONTAINER_MIN_WIDTH = STEP_WIDTH + 32; // step width + L/R padding
+  const CONTAINER_MIN_HEIGHT = 108; // top padding 60 + 1 step (32) + bottom 16
 
   const elk = new ELK();
   const nodeTypes: NodeTypes = {
@@ -507,7 +512,14 @@
             };
           }),
         };
-        return await elk.layout(containerGraph);
+        const laidOut = await elk.layout(containerGraph);
+        if ((laidOut.width ?? 0) < CONTAINER_MIN_WIDTH) {
+          laidOut.width = CONTAINER_MIN_WIDTH;
+        }
+        if ((laidOut.height ?? 0) < CONTAINER_MIN_HEIGHT) {
+          laidOut.height = CONTAINER_MIN_HEIGHT;
+        }
+        return laidOut;
       }),
     );
 

--- a/apps/console/src/lib/components/WorkflowThroughputChart.svelte
+++ b/apps/console/src/lib/components/WorkflowThroughputChart.svelte
@@ -5,6 +5,7 @@
   import * as Chart from "$lib/components/ui/chart/index.js";
   import * as Select from "$lib/components/ui/select/index.js";
   import * as ToggleGroup from "$lib/components/ui/toggle-group/index.js";
+  import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
   type ApiBucket = {
     ts: string;
@@ -25,37 +26,42 @@
 
   let range = $state<Range>(loadRange());
   let data = $state<{ ts: Date; succeeded: number; errored: number; running: number }[]>([]);
-  let timer: ReturnType<typeof setInterval> | undefined;
+  let handle: SubscriptionHandle | null = null;
 
-  async function refresh() {
-    try {
-      const r = await fetch(`/api/stats/timeseries?range=${range}`);
-      if (!r.ok) return;
-      const buckets: ApiBucket[] = await r.json();
-      data = buckets.map((b) => ({
-        ts: new Date(b.ts),
-        succeeded: b.succeeded,
-        errored: b.errored,
-        running: b.running,
-      }));
-    } catch {
-      // silently ignore — the dashboard's main fetch will surface the error
-    }
+  function applySnapshot(payload: unknown): void {
+    if (!Array.isArray(payload)) return;
+    data = (payload as ApiBucket[]).map((b) => ({
+      ts: new Date(b.ts),
+      succeeded: b.succeeded,
+      errored: b.errored,
+      running: b.running,
+    }));
   }
 
+  // Persist range + push update_params on change so the same subscription
+  // re-keys server-side instead of unsubscribing + resubscribing.
   $effect(() => {
     if (typeof localStorage !== "undefined") {
       localStorage.setItem(RANGE_STORAGE_KEY, range);
     }
-    refresh();
+    handle?.updateParams({ range });
   });
 
   onMount(() => {
-    timer = setInterval(refresh, 10_000);
+    handle = realtimeClient.subscribe(
+      "stats.timeseries",
+      { range },
+      {
+        onSnapshot: applySnapshot,
+        onUpdate: applySnapshot,
+        // Errors are intentionally silent — the dashboard's main connection
+        // indicator already surfaces server-side problems.
+      },
+    );
   });
 
   onDestroy(() => {
-    if (timer) clearInterval(timer);
+    handle?.dispose();
   });
 
   const rangeLabel = $derived.by(() => {

--- a/apps/console/src/lib/connection-state.svelte.ts
+++ b/apps/console/src/lib/connection-state.svelte.ts
@@ -1,26 +1,73 @@
 import type { Health, SqlDiagnostics } from "$lib/connection-diagnostics";
+import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
 class ConnectionState {
   health = $state<Health | null>(null);
+  // `fetchError` historically meant "we failed to fetch /healthz". Under the
+  // realtime layer it represents either a failed snapshot from the server-side
+  // health channel OR a closed/connecting websocket — the consumer-visible
+  // condition is the same: "we don't have a current health reading".
   fetchError = $state<string | null>(null);
   diagnostics = $state<SqlDiagnostics | null>(null);
   diagnosticsLoading = $state(false);
   diagnosticsError = $state<string | null>(null);
   sheetOpen = $state(false);
 
-  async refreshHealth() {
-    try {
-      const res = await fetch("/healthz");
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      this.health = (await res.json()) as Health;
+  private handle: SubscriptionHandle | null = null;
+  private refs = 0;
+  private connInterval: ReturnType<typeof setInterval> | null = null;
+
+  start(): void {
+    this.refs += 1;
+    if (this.handle) return;
+    const apply = (data: unknown) => {
+      this.health = data as Health;
       this.fetchError = null;
-    } catch (e) {
-      this.health = null;
-      this.fetchError = e instanceof Error ? e.message : String(e);
-    }
+      // Auto-fetch SQL diagnostics on the first up-health snapshot. The
+      // original code did this in the layout's onMount after the awaited
+      // refreshHealth(); preserving that here keeps the indicator turning
+      // yellow on schema drift without extra wiring at every callsite.
+      if (this.health.database === "up" && !this.diagnostics && !this.diagnosticsLoading) {
+        void this.ensureDiagnostics();
+      }
+    };
+    this.handle = realtimeClient.subscribe("health", undefined, {
+      onSnapshot: apply,
+      onUpdate: apply,
+      onError: (_code, message) => {
+        // Preserve the prior contract: any data-fetch failure surfaces as
+        // `fetchError`, and the indicator falls back to "disconnected".
+        this.fetchError = message;
+      },
+    });
+    // Surface persistent disconnects as fetchError so the connection
+    // indicator turns red. Polled rather than effect-driven because the
+    // realtime client's `connectionStatus` is a `$state` only meaningful
+    // inside Svelte reactivity contexts; this loop is portable.
+    this.connInterval = setInterval(() => {
+      const status = realtimeClient.connectionStatus;
+      if (status === "open") {
+        // Snapshot will follow shortly; `onSnapshot` clears the error.
+        return;
+      }
+      // We've been closed/connecting AND we have no recent health — surface
+      // as a fetch error. Once a snapshot lands, onSnapshot clears this.
+      if (!this.health) {
+        this.fetchError = realtimeClient.lastError ?? "websocket disconnected";
+      }
+    }, 1000);
   }
 
-  async ensureDiagnostics() {
+  stop(): void {
+    if (this.refs > 0) this.refs -= 1;
+    if (this.refs > 0) return;
+    this.handle?.dispose();
+    this.handle = null;
+    if (this.connInterval) clearInterval(this.connInterval);
+    this.connInterval = null;
+  }
+
+  async ensureDiagnostics(): Promise<void> {
     if (this.health?.database !== "up" || this.diagnosticsLoading || this.diagnostics) return;
 
     this.diagnosticsError = null;

--- a/apps/console/src/lib/connection-state.svelte.ts
+++ b/apps/console/src/lib/connection-state.svelte.ts
@@ -23,12 +23,13 @@ class ConnectionState {
     const apply = (data: unknown) => {
       this.health = data as Health;
       this.fetchError = null;
-      // Auto-fetch SQL diagnostics on the first up-health snapshot. The
-      // original code did this in the layout's onMount after the awaited
-      // refreshHealth(); preserving that here keeps the indicator turning
-      // yellow on schema drift without extra wiring at every callsite.
       if (this.health.database === "up" && !this.diagnostics && !this.diagnosticsLoading) {
-        void this.ensureDiagnostics();
+        // First-paint fetch only — the recovery loop in `connInterval` below
+        // handles re-polling when the schema starts missing and later
+        // materializes (e.g. a fresh DB that a DBOS app connects to mid-
+        // session). The health channel dedupes identical snapshots, so we
+        // can't rely on update frames as the recovery trigger.
+        void this.refreshDiagnostics();
       }
     };
     this.handle = realtimeClient.subscribe("health", undefined, {
@@ -40,20 +41,35 @@ class ConnectionState {
         this.fetchError = message;
       },
     });
-    // Surface persistent disconnects as fetchError so the connection
-    // indicator turns red. Polled rather than effect-driven because the
-    // realtime client's `connectionStatus` is a `$state` only meaningful
-    // inside Svelte reactivity contexts; this loop is portable.
+    // Two responsibilities folded into one ticker:
+    // 1. Surface persistent WS disconnects as `fetchError` so the indicator
+    //    turns red. Polled rather than effect-driven because the realtime
+    //    client's `connectionStatus` is a `$state` only meaningful inside
+    //    Svelte reactivity contexts.
+    // 2. Re-poll `/api/sql-diagnostics` on a 5s cadence while the last
+    //    result reported issues — the health channel dedupes identical
+    //    snapshots, so we can't piggyback the recovery on update frames.
+    let diagTickCounter = 0;
     this.connInterval = setInterval(() => {
       const status = realtimeClient.connectionStatus;
-      if (status === "open") {
-        // Snapshot will follow shortly; `onSnapshot` clears the error.
+      if (status !== "open") {
+        if (!this.health) {
+          this.fetchError = realtimeClient.lastError ?? "websocket disconnected";
+        }
         return;
       }
-      // We've been closed/connecting AND we have no recent health — surface
-      // as a fetch error. Once a snapshot lands, onSnapshot clears this.
-      if (!this.health) {
-        this.fetchError = realtimeClient.lastError ?? "websocket disconnected";
+      // Snapshot will follow shortly; `onSnapshot` clears any prior error.
+      // While issues are reported, retry every 5 ticks (≈5s) — this is the
+      // "DBOS app just connected, schema is now there" recovery path.
+      diagTickCounter += 1;
+      if (
+        diagTickCounter % 5 === 0
+        && this.diagnostics
+        && !this.diagnostics.ok
+        && this.health?.database === "up"
+        && !this.diagnosticsLoading
+      ) {
+        void this.refreshDiagnostics();
       }
     }, 1000);
   }
@@ -69,7 +85,14 @@ class ConnectionState {
 
   async ensureDiagnostics(): Promise<void> {
     if (this.health?.database !== "up" || this.diagnosticsLoading || this.diagnostics) return;
+    await this.refreshDiagnostics();
+  }
 
+  // Force a re-fetch even when `diagnostics` is already populated. Used by
+  // the health-update path to converge the schema indicator after the dbos.*
+  // tables come into existence on a previously-empty DB.
+  async refreshDiagnostics(): Promise<void> {
+    if (this.health?.database !== "up" || this.diagnosticsLoading) return;
     this.diagnosticsError = null;
     this.diagnosticsLoading = true;
     try {

--- a/apps/console/src/lib/realtime/client.svelte.ts
+++ b/apps/console/src/lib/realtime/client.svelte.ts
@@ -1,0 +1,347 @@
+/**
+ * RealtimeClient — singleton-friendly WS subscription manager.
+ *
+ * Lazy connect: opens the socket on the first subscribe(). Reconnects with
+ * jittered exponential backoff (capped at 8s) and replays every live
+ * subscription on reconnect, so callers don't need to handle reconnection
+ * logic themselves. Heartbeat ping/pong detects half-open sockets.
+ *
+ * The client is a `.svelte.ts` module so its reactive state ($state-backed
+ * `connectionStatus` and `lastError`) can be consumed directly from
+ * components.
+ */
+
+import type {
+  ClientMessage,
+  ConnectionStatus,
+  ServerMessage,
+  SnapshotMessage,
+  UpdateMessage,
+} from "./protocol";
+
+export type SubscriptionHandlers = {
+  /**
+   * Called for the first payload AND for every replay snapshot delivered
+   * after a reconnect or `update_params`. Treat as "fresh state — replace
+   * what you had".
+   */
+  onSnapshot: (data: unknown, msg: SnapshotMessage) => void;
+  /** Called for in-place updates between snapshots. */
+  onUpdate: (data: unknown, msg: UpdateMessage) => void;
+  /** Channel-level errors (server-side cursor/snapshot failures). */
+  onError?: (code: string, message: string) => void;
+};
+
+export type SubscriptionHandle = {
+  /** Re-key this subscription on the server without unsubscribing first. */
+  updateParams: (params: Record<string, unknown> | undefined) => void;
+  /** Unsubscribe and forget. Idempotent. */
+  dispose: () => void;
+};
+
+type InternalSub = {
+  subId: string;
+  channel: string;
+  params: Record<string, unknown> | undefined;
+  handlers: SubscriptionHandlers;
+};
+
+export type ClientOptions = {
+  /** Socket factory. Defaults to `new WebSocket(url)`. Tests inject a fake. */
+  socketFactory?: (url: string) => WebSocket;
+  /** Override the URL. Defaults to `${ws|wss}://${location.host}/ws`. */
+  url?: string;
+  /**
+   * Heartbeat interval. A `ping` is sent every `heartbeatMs`; if no `pong`
+   * arrives within `heartbeatTimeoutMs`, the socket is force-closed.
+   */
+  heartbeatMs?: number;
+  heartbeatTimeoutMs?: number;
+  /** Initial reconnect delay; doubles each attempt up to `maxBackoffMs`. */
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+};
+
+const DEFAULTS = {
+  heartbeatMs: 20_000,
+  heartbeatTimeoutMs: 10_000,
+  initialBackoffMs: 250,
+  maxBackoffMs: 8_000,
+};
+
+export class RealtimeClient {
+  // Reactive state — read these from components / .svelte.ts wrappers.
+  connectionStatus = $state<ConnectionStatus>("closed");
+  lastError = $state<string | null>(null);
+
+  private readonly subs = new Map<string, InternalSub>();
+  private socket: WebSocket | null = null;
+  private nextId = 1;
+  private backoffAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private pongTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  private readonly opts: Required<Omit<ClientOptions, "url" | "socketFactory">> & {
+    url: string;
+    socketFactory: (url: string) => WebSocket;
+  };
+
+  constructor(options: ClientOptions = {}) {
+    const url =
+      options.url ??
+      (typeof window !== "undefined"
+        ? `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`
+        : "ws://localhost/ws");
+    this.opts = {
+      url,
+      socketFactory: options.socketFactory ?? ((u) => new WebSocket(u)),
+      heartbeatMs: options.heartbeatMs ?? DEFAULTS.heartbeatMs,
+      heartbeatTimeoutMs: options.heartbeatTimeoutMs ?? DEFAULTS.heartbeatTimeoutMs,
+      initialBackoffMs: options.initialBackoffMs ?? DEFAULTS.initialBackoffMs,
+      maxBackoffMs: options.maxBackoffMs ?? DEFAULTS.maxBackoffMs,
+    };
+  }
+
+  // ---- Public API --------------------------------------------------------
+
+  subscribe(
+    channel: string,
+    params: Record<string, unknown> | undefined,
+    handlers: SubscriptionHandlers,
+  ): SubscriptionHandle {
+    if (this.disposed) {
+      throw new Error("RealtimeClient: subscribe called after close()");
+    }
+    const subId = `s${this.nextId++}`;
+    const sub: InternalSub = { subId, channel, params, handlers };
+    this.subs.set(subId, sub);
+
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.send({ type: "subscribe", sub_id: subId, channel, params });
+    } else {
+      // Will be sent on `open` via `replaySubscriptions`. Make sure we've
+      // started the connect dance.
+      this.ensureConnected();
+    }
+
+    return {
+      updateParams: (newParams) => this.updateParams(subId, newParams),
+      dispose: () => this.unsubscribe(subId),
+    };
+  }
+
+  /** Force-close the socket and stop reconnecting. Used in tests / cleanup. */
+  close(): void {
+    this.disposed = true;
+    this.clearTimers();
+    this.subs.clear();
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {
+        // Ignore — already closed.
+      }
+      this.socket = null;
+    }
+    this.connectionStatus = "closed";
+  }
+
+  // ---- Internals ---------------------------------------------------------
+
+  private ensureConnected(): void {
+    if (this.disposed) return;
+    if (this.socket) return; // open or connecting
+    this.connect();
+  }
+
+  private connect(): void {
+    if (this.disposed) return;
+    this.connectionStatus = "connecting";
+    let socket: WebSocket;
+    try {
+      socket = this.opts.socketFactory(this.opts.url);
+    } catch (e) {
+      this.lastError = e instanceof Error ? e.message : String(e);
+      this.scheduleReconnect();
+      return;
+    }
+    this.socket = socket;
+
+    socket.onopen = () => this.handleOpen();
+    socket.onmessage = (ev) => this.handleMessage(ev);
+    socket.onerror = () => {
+      // The browser doesn't expose error details; rely on `onclose`
+      // following up. Just record that something went wrong.
+      this.lastError = "websocket error";
+    };
+    socket.onclose = () => this.handleClose();
+  }
+
+  private handleOpen(): void {
+    this.connectionStatus = "open";
+    this.lastError = null;
+    this.backoffAttempt = 0;
+    this.replaySubscriptions();
+    this.startHeartbeat();
+  }
+
+  private handleClose(): void {
+    this.socket = null;
+    this.stopHeartbeat();
+    if (this.disposed) {
+      this.connectionStatus = "closed";
+      return;
+    }
+    if (this.subs.size === 0) {
+      // Nothing to keep alive for. Stay closed; `subscribe` will reconnect.
+      this.connectionStatus = "closed";
+      return;
+    }
+    this.scheduleReconnect();
+  }
+
+  private handleMessage(ev: MessageEvent): void {
+    let msg: ServerMessage;
+    try {
+      msg = JSON.parse(typeof ev.data === "string" ? ev.data : "") as ServerMessage;
+    } catch {
+      this.lastError = "received non-JSON message";
+      return;
+    }
+    if (msg.type === "pong") {
+      this.clearPongTimer();
+      return;
+    }
+    if (msg.type === "snapshot") {
+      const sub = this.subs.get(msg.sub_id);
+      sub?.handlers.onSnapshot(msg.data, msg);
+      return;
+    }
+    if (msg.type === "update") {
+      const sub = this.subs.get(msg.sub_id);
+      sub?.handlers.onUpdate(msg.data, msg);
+      return;
+    }
+    if (msg.type === "error") {
+      if (msg.sub_id) {
+        const sub = this.subs.get(msg.sub_id);
+        sub?.handlers.onError?.(msg.code, msg.message);
+      } else {
+        this.lastError = `${msg.code}: ${msg.message}`;
+      }
+      return;
+    }
+    // ack — ignore by default; useful only for tests.
+  }
+
+  private replaySubscriptions(): void {
+    for (const sub of this.subs.values()) {
+      this.send({
+        type: "subscribe",
+        sub_id: sub.subId,
+        channel: sub.channel,
+        params: sub.params,
+      });
+    }
+  }
+
+  private updateParams(subId: string, params: Record<string, unknown> | undefined): void {
+    const sub = this.subs.get(subId);
+    if (!sub) return;
+    sub.params = params;
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.send({ type: "update_params", sub_id: subId, params });
+    }
+    // If not open: the next replay (on reconnect) will use the new params,
+    // because `sub.params` is the source of truth.
+  }
+
+  private unsubscribe(subId: string): void {
+    if (!this.subs.has(subId)) return;
+    this.subs.delete(subId);
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.send({ type: "unsubscribe", sub_id: subId });
+    }
+    if (this.subs.size === 0 && !this.disposed) {
+      // No live subscriptions — close the socket to avoid keeping it open
+      // for nothing. Next `subscribe` will reopen.
+      if (this.socket) {
+        try {
+          this.socket.close();
+        } catch {
+          /* already closed */
+        }
+      }
+    }
+  }
+
+  private send(msg: ClientMessage): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    try {
+      this.socket.send(JSON.stringify(msg));
+    } catch (e) {
+      this.lastError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  // ---- Heartbeat ---------------------------------------------------------
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+      this.send({ type: "ping" });
+      this.pongTimer = setTimeout(() => {
+        // No pong — assume the connection is half-open. Force-close, which
+        // triggers the reconnect dance via `onclose`.
+        try {
+          this.socket?.close();
+        } catch {
+          /* ignore */
+        }
+      }, this.opts.heartbeatTimeoutMs);
+    }, this.opts.heartbeatMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+    this.clearPongTimer();
+  }
+
+  private clearPongTimer(): void {
+    if (this.pongTimer) clearTimeout(this.pongTimer);
+    this.pongTimer = null;
+  }
+
+  // ---- Reconnect ---------------------------------------------------------
+
+  private scheduleReconnect(): void {
+    if (this.disposed || this.reconnectTimer) return;
+    this.connectionStatus = "connecting";
+    const base = Math.min(
+      this.opts.initialBackoffMs * 2 ** this.backoffAttempt,
+      this.opts.maxBackoffMs,
+    );
+    // ±20% jitter so a fleet of clients doesn't reconnect in lockstep.
+    const jitter = base * (Math.random() * 0.4 - 0.2);
+    const delay = Math.max(50, Math.round(base + jitter));
+    this.backoffAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  private clearTimers(): void {
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    this.stopHeartbeat();
+  }
+}
+
+// Singleton — use this from app code unless you specifically want a separate
+// connection (e.g. tests).
+export const realtimeClient = new RealtimeClient();

--- a/apps/console/src/lib/realtime/client.test.ts
+++ b/apps/console/src/lib/realtime/client.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RealtimeClient } from "./client.svelte";
+import type { ClientMessage, ServerMessage } from "./protocol";
+
+/**
+ * Minimal WebSocket fake. Tests drive the lifecycle manually via
+ * `triggerOpen`, `deliver`, and `triggerClose`. The class records every
+ * outbound message in `sent` for assertions.
+ */
+class FakeWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  readyState: number = 0; // CONNECTING
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  sent: ClientMessage[] = [];
+
+  constructor(public url: string) {}
+
+  send(payload: string): void {
+    this.sent.push(JSON.parse(payload) as ClientMessage);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    // Use plain Event — `CloseEvent` isn't a globally-defined constructor
+    // under vitest's node environment in every Node version, and our
+    // handler doesn't read the event anyway.
+    this.onclose?.(new Event("close") as CloseEvent);
+  }
+
+  triggerOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  deliver(msg: ServerMessage): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(msg) }));
+  }
+}
+
+// Shadow the real WebSocket constants on the fake so the client's
+// `socket.readyState !== WebSocket.OPEN` check works under vitest's node
+// environment (where `WebSocket` is undefined unless we polyfill it).
+beforeEach(() => {
+  // @ts-expect-error - polyfill global for node test env
+  globalThis.WebSocket = FakeWebSocket;
+});
+
+afterEach(() => {
+  // @ts-expect-error - clean up polyfill
+  delete globalThis.WebSocket;
+});
+
+function makeClient(): { client: RealtimeClient; sockets: FakeWebSocket[] } {
+  const sockets: FakeWebSocket[] = [];
+  const client = new RealtimeClient({
+    url: "ws://test/ws",
+    socketFactory: (url) => {
+      const ws = new FakeWebSocket(url);
+      sockets.push(ws);
+      return ws as unknown as WebSocket;
+    },
+    heartbeatMs: 1_000_000, // disable heartbeat for most tests
+    initialBackoffMs: 5,
+    maxBackoffMs: 5,
+  });
+  return { client, sockets };
+}
+
+describe("RealtimeClient", () => {
+  it("opens a socket and sends subscribe on first subscribe()", () => {
+    const { client, sockets } = makeClient();
+    const onSnapshot = vi.fn();
+    const onUpdate = vi.fn();
+
+    client.subscribe("stats", undefined, { onSnapshot, onUpdate });
+    expect(sockets).toHaveLength(1);
+    const ws = sockets[0];
+
+    ws.triggerOpen();
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]).toMatchObject({ type: "subscribe", channel: "stats" });
+
+    client.close();
+  });
+
+  it("delivers snapshot then update to the right handler", () => {
+    const { client, sockets } = makeClient();
+    const handlers = { onSnapshot: vi.fn(), onUpdate: vi.fn() };
+
+    client.subscribe("stats", undefined, handlers);
+    const ws = sockets[0];
+    ws.triggerOpen();
+
+    const subId = (ws.sent[0] as { sub_id: string }).sub_id;
+    ws.deliver({ type: "ack", sub_id: subId, op: "subscribe" });
+    ws.deliver({ type: "snapshot", sub_id: subId, channel: "stats", data: { total: 1 } });
+    ws.deliver({ type: "update", sub_id: subId, channel: "stats", data: { total: 2 } });
+
+    expect(handlers.onSnapshot).toHaveBeenCalledTimes(1);
+    expect(handlers.onSnapshot).toHaveBeenCalledWith({ total: 1 }, expect.any(Object));
+    expect(handlers.onUpdate).toHaveBeenCalledTimes(1);
+    expect(handlers.onUpdate).toHaveBeenCalledWith({ total: 2 }, expect.any(Object));
+
+    client.close();
+  });
+
+  it("queues subscribe when called before socket opens, then flushes on open", () => {
+    const { client, sockets } = makeClient();
+    client.subscribe("stats", undefined, { onSnapshot: vi.fn(), onUpdate: vi.fn() });
+    const ws = sockets[0];
+
+    expect(ws.sent).toHaveLength(0); // socket not open yet
+    ws.triggerOpen();
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0].type).toBe("subscribe");
+
+    client.close();
+  });
+
+  it("replays subscriptions on reconnect", async () => {
+    const { client, sockets } = makeClient();
+    client.subscribe("stats", undefined, { onSnapshot: vi.fn(), onUpdate: vi.fn() });
+    client.subscribe("workflows", { limit: 50 }, { onSnapshot: vi.fn(), onUpdate: vi.fn() });
+
+    const ws1 = sockets[0];
+    ws1.triggerOpen();
+    expect(ws1.sent).toHaveLength(2);
+
+    // Simulate the socket dropping. Backoff is 5ms so a small wait is
+    // enough for the client to schedule + execute the reconnect.
+    ws1.close();
+    // Wait long enough for the reconnect setTimeout to fire (5ms) plus
+    // jitter (±20%). 200ms is plenty.
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(sockets).toHaveLength(2);
+    const ws2 = sockets[1];
+    ws2.triggerOpen();
+    expect(ws2.sent).toHaveLength(2);
+    expect(ws2.sent.map((m) => (m as { channel?: string }).channel).sort()).toEqual([
+      "stats",
+      "workflows",
+    ]);
+
+    client.close();
+  });
+
+  it("dispose() removes the subscription server-side and stops snapshots", () => {
+    const { client, sockets } = makeClient();
+    const handlers = { onSnapshot: vi.fn(), onUpdate: vi.fn() };
+    const sub = client.subscribe("stats", undefined, handlers);
+
+    const ws = sockets[0];
+    ws.triggerOpen();
+    const subId = (ws.sent[0] as { sub_id: string }).sub_id;
+    ws.deliver({ type: "snapshot", sub_id: subId, channel: "stats", data: { total: 1 } });
+    expect(handlers.onSnapshot).toHaveBeenCalledTimes(1);
+
+    sub.dispose();
+    const lastMsg = ws.sent.at(-1);
+    expect(lastMsg?.type).toBe("unsubscribe");
+
+    // Even if the server (mistakenly) keeps sending updates, the client
+    // shouldn't dispatch them to the disposed handler.
+    handlers.onSnapshot.mockClear();
+    handlers.onUpdate.mockClear();
+    ws.deliver({ type: "update", sub_id: subId, channel: "stats", data: { total: 2 } });
+    expect(handlers.onSnapshot).not.toHaveBeenCalled();
+    expect(handlers.onUpdate).not.toHaveBeenCalled();
+
+    client.close();
+  });
+
+  it("updateParams sends update_params over the open socket", () => {
+    const { client, sockets } = makeClient();
+    const sub = client.subscribe(
+      "workflow",
+      { id: "a" },
+      { onSnapshot: vi.fn(), onUpdate: vi.fn() },
+    );
+    const ws = sockets[0];
+    ws.triggerOpen();
+    ws.sent.length = 0;
+
+    sub.updateParams({ id: "b" });
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]).toMatchObject({ type: "update_params", params: { id: "b" } });
+
+    client.close();
+  });
+
+  it("routes channel errors to the subscription's onError", () => {
+    const { client, sockets } = makeClient();
+    const onError = vi.fn();
+    client.subscribe("stats", undefined, {
+      onSnapshot: vi.fn(),
+      onUpdate: vi.fn(),
+      onError,
+    });
+    const ws = sockets[0];
+    ws.triggerOpen();
+    const subId = (ws.sent[0] as { sub_id: string }).sub_id;
+
+    ws.deliver({ type: "error", sub_id: subId, code: "snapshot_failed", message: "DB down" });
+    expect(onError).toHaveBeenCalledWith("snapshot_failed", "DB down");
+
+    client.close();
+  });
+
+  it("closes the socket when the last subscription is disposed", () => {
+    const { client, sockets } = makeClient();
+    const sub = client.subscribe("stats", undefined, { onSnapshot: vi.fn(), onUpdate: vi.fn() });
+    const ws = sockets[0];
+    ws.triggerOpen();
+    expect(ws.readyState).toBe(FakeWebSocket.OPEN);
+
+    sub.dispose();
+    expect(ws.readyState).toBe(FakeWebSocket.CLOSED);
+
+    client.close();
+  });
+
+  it("connectionStatus reflects the socket lifecycle", async () => {
+    const { client, sockets } = makeClient();
+    expect(client.connectionStatus).toBe("closed");
+
+    client.subscribe("stats", undefined, { onSnapshot: vi.fn(), onUpdate: vi.fn() });
+    expect(client.connectionStatus).toBe("connecting");
+
+    sockets[0].triggerOpen();
+    expect(client.connectionStatus).toBe("open");
+
+    sockets[0].close();
+    // After close + reconnect attempt, status drops to "connecting" again.
+    await new Promise((r) => setTimeout(r, 1));
+    expect(["connecting", "closed"]).toContain(client.connectionStatus);
+
+    client.close();
+    expect(client.connectionStatus).toBe("closed");
+  });
+});

--- a/apps/console/src/lib/realtime/index.ts
+++ b/apps/console/src/lib/realtime/index.ts
@@ -1,0 +1,14 @@
+export { realtimeClient, RealtimeClient } from "./client.svelte";
+export { createSubscription } from "./subscribe.svelte";
+export type {
+  ClientMessage,
+  ConnectionStatus,
+  ServerMessage,
+  SnapshotMessage,
+  UpdateMessage,
+  AckMessage,
+  ErrorMessage,
+  PongMessage,
+} from "./protocol";
+export type { Subscription, SubscriptionOptions } from "./subscribe.svelte";
+export type { ClientOptions, SubscriptionHandle, SubscriptionHandlers } from "./client.svelte";

--- a/apps/console/src/lib/realtime/protocol.ts
+++ b/apps/console/src/lib/realtime/protocol.ts
@@ -1,0 +1,71 @@
+/**
+ * Wire protocol for the /ws endpoint.
+ *
+ * Mirrors `packages/server/dbos_argus/realtime/protocol.py`. Channel-specific
+ * payload shapes are deliberately `unknown` here — typed wrappers in
+ * `subscribe.svelte.ts` and channel-specific stores narrow them down.
+ */
+
+export type SubscribeMessage = {
+  type: "subscribe";
+  sub_id: string;
+  channel: string;
+  params?: Record<string, unknown>;
+};
+
+export type UnsubscribeMessage = {
+  type: "unsubscribe";
+  sub_id: string;
+};
+
+export type UpdateParamsMessage = {
+  type: "update_params";
+  sub_id: string;
+  params?: Record<string, unknown>;
+};
+
+export type PingMessage = { type: "ping" };
+
+export type ClientMessage =
+  | SubscribeMessage
+  | UnsubscribeMessage
+  | UpdateParamsMessage
+  | PingMessage;
+
+export type SnapshotMessage = {
+  type: "snapshot";
+  sub_id: string;
+  channel: string;
+  data: unknown;
+};
+
+export type UpdateMessage = {
+  type: "update";
+  sub_id: string;
+  channel: string;
+  data: unknown;
+};
+
+export type ErrorMessage = {
+  type: "error";
+  sub_id?: string | null;
+  code: string;
+  message: string;
+};
+
+export type PongMessage = { type: "pong" };
+
+export type AckMessage = {
+  type: "ack";
+  sub_id: string;
+  op: "subscribe" | "unsubscribe" | "update_params";
+};
+
+export type ServerMessage =
+  | SnapshotMessage
+  | UpdateMessage
+  | ErrorMessage
+  | PongMessage
+  | AckMessage;
+
+export type ConnectionStatus = "closed" | "connecting" | "open";

--- a/apps/console/src/lib/realtime/subscribe.svelte.ts
+++ b/apps/console/src/lib/realtime/subscribe.svelte.ts
@@ -1,0 +1,76 @@
+/**
+ * `createSubscription<T>(channel, params)` — typed reactive wrapper around
+ * `RealtimeClient.subscribe`.
+ *
+ * Returns a $state-backed object that components can read from directly:
+ *
+ *   const stats = createSubscription<Stats>("stats");
+ *   $effect(() => () => stats.dispose()); // cleanup on unmount
+ *   // template: {stats.data?.total ?? "—"}
+ */
+
+import { realtimeClient, type RealtimeClient } from "./client.svelte";
+
+export type Subscription<T> = {
+  /** Latest server payload, or `null` until the first snapshot lands. */
+  data: T | null;
+  /** Channel-level error from the server, or null if none. */
+  error: string | null;
+  /** True once at least one snapshot has been delivered. */
+  ready: boolean;
+  /** Re-key the subscription. The next snapshot will reflect the new params. */
+  updateParams: (params: Record<string, unknown> | undefined) => void;
+  /** Drop the subscription. Idempotent. */
+  dispose: () => void;
+};
+
+export type SubscriptionOptions = {
+  /** Override the singleton client — primarily for tests. */
+  client?: RealtimeClient;
+};
+
+export function createSubscription<T = unknown>(
+  channel: string,
+  params: Record<string, unknown> | undefined = undefined,
+  options: SubscriptionOptions = {},
+): Subscription<T> {
+  const client = options.client ?? realtimeClient;
+
+  // Mutable reactive state. Returned object methods read/write these fields
+  // by capturing `state` in their closures — Svelte's `$state` proxies pick
+  // up the writes regardless of how the object is structured.
+  const state = $state({
+    data: null as T | null,
+    error: null as string | null,
+    ready: false,
+  });
+
+  const handle = client.subscribe(channel, params, {
+    onSnapshot: (data) => {
+      state.data = data as T;
+      state.error = null;
+      state.ready = true;
+    },
+    onUpdate: (data) => {
+      state.data = data as T;
+      state.error = null;
+    },
+    onError: (_code, message) => {
+      state.error = message;
+    },
+  });
+
+  return {
+    get data() {
+      return state.data;
+    },
+    get error() {
+      return state.error;
+    },
+    get ready() {
+      return state.ready;
+    },
+    updateParams: (newParams) => handle.updateParams(newParams),
+    dispose: () => handle.dispose(),
+  };
+}

--- a/apps/console/src/lib/stats.svelte.ts
+++ b/apps/console/src/lib/stats.svelte.ts
@@ -1,3 +1,5 @@
+import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
+
 export type Stats = {
   total: number;
   in_flight: number;
@@ -11,15 +13,36 @@ class StatsState {
   data = $state<Stats | null>(null);
   error = $state<string | null>(null);
 
-  async refresh() {
-    try {
-      const res = await fetch("/api/stats");
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      this.data = (await res.json()) as Stats;
-      this.error = null;
-    } catch (e) {
-      this.error = e instanceof Error ? e.message : String(e);
-    }
+  private handle: SubscriptionHandle | null = null;
+  // Reference count so multiple components can call start()/stop() without
+  // tearing each other's subscription down. The layout currently owns the
+  // single starter — but counting cheaply guards against future callers.
+  private refs = 0;
+
+  /** Subscribe to the realtime `stats` channel. Idempotent. */
+  start(): void {
+    this.refs += 1;
+    if (this.handle) return;
+    this.handle = realtimeClient.subscribe("stats", undefined, {
+      onSnapshot: (data) => {
+        this.data = data as Stats;
+        this.error = null;
+      },
+      onUpdate: (data) => {
+        this.data = data as Stats;
+        this.error = null;
+      },
+      onError: (_code, message) => {
+        this.error = message;
+      },
+    });
+  }
+
+  stop(): void {
+    if (this.refs > 0) this.refs -= 1;
+    if (this.refs > 0) return;
+    this.handle?.dispose();
+    this.handle = null;
   }
 }
 

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -82,7 +82,6 @@
     return pathname === href || pathname === base || pathname.startsWith(base + "/");
   }
 
-  let timer: ReturnType<typeof setInterval> | undefined;
   let isDark = $state(false);
   // Sidebar collapsed/expanded state survives reloads. SSR has no window, so
   // we default to expanded and correct on hydrate. The shadcn provider also
@@ -100,15 +99,11 @@
       // localStorage may be unavailable (private mode, sandboxed) — fall
       // back to the default expanded state.
     }
-    void (async () => {
-      await connectionState.refreshHealth();
-      await connectionState.ensureDiagnostics();
-    })();
-    void statsState.refresh();
-    timer = setInterval(() => {
-      void connectionState.refreshHealth();
-      void statsState.refresh();
-    }, 5000);
+    // Realtime subscriptions: the server pushes health + stats; no client
+    // polling needed. Diagnostics auto-fetch from connectionState once the
+    // first up-health snapshot lands.
+    connectionState.start();
+    statsState.start();
   });
 
   function persistSidebarOpen(value: boolean) {
@@ -120,7 +115,8 @@
   }
 
   onDestroy(() => {
-    if (timer) clearInterval(timer);
+    connectionState.stop();
+    statsState.stop();
   });
 
   function toggleTheme() {

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -22,10 +22,11 @@
   import * as Table from "$lib/components/ui/table/index.js";
   import { Badge } from "$lib/components/ui/badge/index.js";
   import WorkflowThroughputChart from "$lib/components/WorkflowThroughputChart.svelte";
+  import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
   let recents = $state<Workflow[] | null>(null);
   let error = $state<string | null>(null);
-  let timer: ReturnType<typeof setInterval> | undefined;
+  let recentsHandle: SubscriptionHandle | null = null;
 
   const stats = $derived(statsState.data);
 
@@ -36,29 +37,30 @@
     };
   });
 
-  async function refresh() {
-    try {
-      const [, w] = await Promise.all([
-        statsState.refresh(),
-        fetch("/api/workflows?limit=8&grouped=false").then((r) => {
-          if (!r.ok) throw new Error(`workflows HTTP ${r.status}`);
-          return r.json() as Promise<Workflow[]>;
-        }),
-      ]);
-      recents = w;
-      error = statsState.error;
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    }
+  function applyRecents(data: unknown): void {
+    if (!Array.isArray(data)) return;
+    recents = data as Workflow[];
+    // Only clear the local error; the layout-level statsState may still
+    // have its own error which we surface below.
+    error = statsState.error;
   }
 
   onMount(() => {
-    refresh();
-    timer = setInterval(refresh, 5000);
+    recentsHandle = realtimeClient.subscribe(
+      "workflows",
+      { limit: 8, grouped: false },
+      {
+        onSnapshot: applyRecents,
+        onUpdate: applyRecents,
+        onError: (_code, message) => {
+          error = message;
+        },
+      },
+    );
   });
 
   onDestroy(() => {
-    if (timer) clearInterval(timer);
+    recentsHandle?.dispose();
   });
 
   const inFlightHref = "/workflows/?status=PENDING&status=ENQUEUED&status=DELAYED";

--- a/apps/console/src/routes/notifications/+page.svelte
+++ b/apps/console/src/routes/notifications/+page.svelte
@@ -13,6 +13,7 @@
   import Check from "@lucide/svelte/icons/check";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import Eye from "@lucide/svelte/icons/eye";
+  import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
   type WorkflowAncestor = {
     workflow_id: string;
@@ -38,7 +39,7 @@
   let view = $state<View>("pending");
   let items = $state<Notification[] | null>(null);
   let error = $state<string | null>(null);
-  let timer: ReturnType<typeof setInterval> | undefined;
+  let handle: SubscriptionHandle | null = null;
   let selected = $state<Notification | null>(null);
   let preferredMode = $state<ViewMode>("decoded");
 
@@ -49,39 +50,41 @@
     };
   });
 
-  async function refresh() {
-    try {
-      const url =
-        view === "pending"
-          ? "/api/notifications?consumed=false"
-          : "/api/notifications";
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const next = (await res.json()) as Notification[];
-      items = next;
-      // Keep the selected sheet's content fresh if the row is still in the list.
-      if (selected) {
-        const updated = next.find((n) => n.message_uuid === selected!.message_uuid);
-        selected = updated ?? selected;
-      }
-      error = null;
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-      items = null;
-    }
+  function buildParams(): Record<string, unknown> {
+    return view === "pending" ? { consumed: false } : {};
   }
 
+  function applySnapshot(data: unknown): void {
+    if (!Array.isArray(data)) return;
+    const next = data as Notification[];
+    items = next;
+    // Keep the selected sheet's content fresh if the row is still in the list.
+    if (selected) {
+      const updated = next.find((n) => n.message_uuid === selected!.message_uuid);
+      selected = updated ?? selected;
+    }
+    error = null;
+  }
+
+  // View-toggle changes route through update_params so the same poller is
+  // re-keyed on the server instead of torn down.
   $effect(() => {
     view;
-    refresh();
+    handle?.updateParams(buildParams());
   });
 
   onMount(() => {
-    timer = setInterval(refresh, 5000);
+    handle = realtimeClient.subscribe("notifications", buildParams(), {
+      onSnapshot: applySnapshot,
+      onUpdate: applySnapshot,
+      onError: (_code, message) => {
+        error = message;
+      },
+    });
   });
 
   onDestroy(() => {
-    if (timer) clearInterval(timer);
+    handle?.dispose();
   });
 
   const messagePayload = $derived.by<{

--- a/apps/console/src/routes/schedules/+page.svelte
+++ b/apps/console/src/routes/schedules/+page.svelte
@@ -5,6 +5,7 @@
   import * as Table from "$lib/components/ui/table/index.js";
   import { Badge } from "$lib/components/ui/badge/index.js";
   import { formatStatus } from "$lib/workflow-tree";
+  import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
   type WorkflowSchedule = {
     schedule_id: string;
@@ -21,7 +22,7 @@
 
   let schedules = $state<WorkflowSchedule[] | null>(null);
   let error = $state<string | null>(null);
-  let timer: ReturnType<typeof setInterval> | undefined;
+  let handle: SubscriptionHandle | null = null;
 
   $effect(() => {
     breadcrumb.items = [{ label: "Schedules", icon: "schedules" }];
@@ -30,25 +31,27 @@
     };
   });
 
-  async function refresh() {
-    try {
-      const res = await fetch("/api/schedules");
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      schedules = (await res.json()) as WorkflowSchedule[];
-      error = null;
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-      schedules = null;
-    }
-  }
-
   onMount(() => {
-    refresh();
-    timer = setInterval(refresh, 10000);
+    handle = realtimeClient.subscribe("schedules", undefined, {
+      onSnapshot: (data) => {
+        if (Array.isArray(data)) {
+          schedules = data as WorkflowSchedule[];
+          error = null;
+        }
+      },
+      onUpdate: (data) => {
+        if (Array.isArray(data)) {
+          schedules = data as WorkflowSchedule[];
+        }
+      },
+      onError: (_code, message) => {
+        error = message;
+      },
+    });
   });
 
   onDestroy(() => {
-    if (timer) clearInterval(timer);
+    handle?.dispose();
   });
 
   function statusClass(status: string): string {

--- a/apps/console/src/routes/workflows/+page.svelte
+++ b/apps/console/src/routes/workflows/+page.svelte
@@ -33,6 +33,7 @@
   import { STATUS_LABELS, WORKFLOW_STATUSES } from "$lib/workflow-status";
   import { breadcrumb } from "$lib/breadcrumb.svelte";
   import { statsState } from "$lib/stats.svelte";
+  import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
   const queueName = $derived(page.url.searchParams.get("queue_name") ?? "");
 
@@ -58,15 +59,19 @@
 
   let workflows = $state<Workflow[] | null>(null);
   // ENQUEUED rows live in a pinned strip above the main list; the server
-  // hides them from /api/workflows by default, and the strip fetches them
-  // explicitly via ?status=ENQUEUED.
+  // hides them from /api/workflows by default, and the strip subscribes
+  // separately with `status: ["ENQUEUED"]`.
   let enqueued = $state<Workflow[]>([]);
   // Collapse state survives reloads/navigation; SSR has no window so the
   // initial value defaults to expanded and gets corrected on hydrate.
   const ENQUEUED_COLLAPSED_KEY = "argus.workflows.enqueuedCollapsed";
   let enqueuedCollapsed = $state(false);
   let error = $state<string | null>(null);
-  let timer: ReturnType<typeof setInterval> | undefined;
+  // Realtime subscription handles. The page holds two: the main filtered
+  // list and the pinned ENQUEUED strip. Both push fresh snapshots whenever
+  // anything in dbos.workflow_status / operation_outputs changes.
+  let mainHandle: SubscriptionHandle | null = null;
+  let enqueuedHandle: SubscriptionHandle | null = null;
 
   // Filter options derived from the canonical status list — adding a new DBOS
   // workflow status only requires editing `$lib/workflow-status.ts`. ENQUEUED
@@ -241,67 +246,74 @@
     selectedStatuses = next;
   }
 
-  function buildQuery(): string {
-    const params = new URLSearchParams();
-    if (filters.q.trim()) params.set("q", filters.q.trim());
-    if (queueName) params.set("queue_name", queueName);
+  function buildMainParams(): Record<string, unknown> {
+    const p: Record<string, unknown> = {
+      grouped,
+      hide_scheduled: hideScheduled,
+    };
+    if (filters.q.trim()) p.q = filters.q.trim();
+    if (queueName) p.queue_name = queueName;
     const tz = getLocalTimeZone();
     if (dateRange.start) {
-      params.set("started_after", dateRange.start.toDate(tz).toISOString());
+      p.started_after = dateRange.start.toDate(tz).toISOString();
     }
     if (dateRange.end) {
       const end = dateRange.end.toDate(tz);
       end.setHours(23, 59, 59, 999);
-      params.set("started_before", end.toISOString());
+      p.started_before = end.toISOString();
     }
     if (selectedStatuses.size > 0 && selectedStatuses.size < STATUS_OPTIONS.length) {
-      for (const s of selectedStatuses) params.append("status", s);
+      p.status = Array.from(selectedStatuses);
     }
-    if (hideScheduled) params.set("hide_scheduled", "true");
-    params.set("grouped", grouped ? "true" : "false");
-    return params.toString();
+    return p;
   }
 
-  function buildEnqueuedQuery(): string {
+  function buildEnqueuedParams(): Record<string, unknown> {
     // The strip is a top-of-page "what's currently waiting to run" pin and is
     // intentionally independent of the toolbar filters below it. The only
     // input it honors is the URL `queue_name` route scope — when the page is
     // scoped to a single queue, the strip is too.
-    const params = new URLSearchParams();
-    if (queueName) params.set("queue_name", queueName);
-    params.set("status", "ENQUEUED");
-    params.set("grouped", "false");
-    params.set("limit", "50");
-    return params.toString();
+    const p: Record<string, unknown> = {
+      grouped: false,
+      limit: 50,
+      status: ["ENQUEUED"],
+    };
+    if (queueName) p.queue_name = queueName;
+    return p;
   }
 
-  async function refresh() {
-    try {
-      const enqRes = await fetch("/api/workflows?" + buildEnqueuedQuery());
-      if (!enqRes.ok) throw new Error(`HTTP ${enqRes.status}`);
-      enqueued = (await enqRes.json()) as Workflow[];
-      if (selectedStatuses.size === 0) {
-        workflows = [];
-      } else {
-        const listRes = await fetch("/api/workflows?" + buildQuery());
-        if (!listRes.ok) throw new Error(`HTTP ${listRes.status}`);
-        workflows = (await listRes.json()) as Workflow[];
-      }
+  function applyMainSnapshot(data: unknown): void {
+    if (Array.isArray(data)) {
+      workflows = data as Workflow[];
       error = null;
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-      workflows = null;
-      enqueued = [];
+    }
+  }
+  function applyEnqueuedSnapshot(data: unknown): void {
+    if (Array.isArray(data)) {
+      enqueued = data as Workflow[];
     }
   }
 
-  let debounce: ReturnType<typeof setTimeout> | undefined;
-  function scheduleRefresh() {
-    if (debounce) clearTimeout(debounce);
-    debounce = setTimeout(refresh, 250);
+  // Filter changes flow through update_params, not new subscriptions —
+  // keeps the same poller alive on the server when only one knob moved.
+  // 250ms debounce coalesces bursty change events (e.g. selecting multiple
+  // statuses in a popover) into a single round-trip.
+  let updateDebounce: ReturnType<typeof setTimeout> | undefined;
+  function scheduleParamUpdate() {
+    if (updateDebounce) clearTimeout(updateDebounce);
+    updateDebounce = setTimeout(() => {
+      // selectedStatuses === empty set means "show nothing" client-side
+      // (rather than "no filter" which the server would interpret as all).
+      // Track that locally; don't push an impossible filter to the server.
+      if (selectedStatuses.size === 0) {
+        workflows = [];
+      }
+      mainHandle?.updateParams(buildMainParams());
+      enqueuedHandle?.updateParams(buildEnqueuedParams());
+    }, 250);
   }
 
-  // Re-fetch whenever any filter/view dimension changes.
+  // Re-evaluate subscription params whenever any filter/view dimension changes.
   $effect(() => {
     filters.q;
     dateRange.start;
@@ -310,7 +322,7 @@
     hideScheduled;
     grouped;
     queueName;
-    scheduleRefresh();
+    scheduleParamUpdate();
   });
 
   $effect(() => {
@@ -329,8 +341,17 @@
       // localStorage may be unavailable (private mode, sandboxed) — fall back
       // to defaults.
     }
-    refresh();
-    timer = setInterval(refresh, 5000);
+    mainHandle = realtimeClient.subscribe("workflows", buildMainParams(), {
+      onSnapshot: applyMainSnapshot,
+      onUpdate: applyMainSnapshot,
+      onError: (_code, message) => {
+        error = message;
+      },
+    });
+    enqueuedHandle = realtimeClient.subscribe("workflows", buildEnqueuedParams(), {
+      onSnapshot: applyEnqueuedSnapshot,
+      onUpdate: applyEnqueuedSnapshot,
+    });
   });
 
   function toggleEnqueuedCollapsed() {
@@ -343,8 +364,9 @@
   }
 
   onDestroy(() => {
-    if (timer) clearInterval(timer);
-    if (debounce) clearTimeout(debounce);
+    mainHandle?.dispose();
+    enqueuedHandle?.dispose();
+    if (updateDebounce) clearTimeout(updateDebounce);
     if (qDebounce) clearTimeout(qDebounce);
   });
 

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -11,6 +11,7 @@
     type Step,
   } from "$lib/components/WorkflowFlow.svelte";
   import { breadcrumb } from "$lib/breadcrumb.svelte";
+  import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
   type WorkflowDetail = {
     workflow_id: string;
@@ -75,11 +76,20 @@
     (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
   }
 
+  let workflowHandle: SubscriptionHandle | null = null;
+  // First snapshot for a given workflow seeds `selection`; subsequent updates
+  // must NOT clobber the user's choice — they may have clicked a step.
+  let selectionSeeded = false;
+
   $effect(() => {
     const id = workflowId;
+    // Tear down any prior subscription before rebinding to the new id.
+    workflowHandle?.dispose();
+    workflowHandle = null;
     detail = null;
     error = null;
     selection = null;
+    selectionSeeded = false;
     // Different workflow → wipe cache; a stale entry from a previous
     // workflow's family would never be hit anyway, but cleanup keeps memory
     // bounded across navigations.
@@ -87,18 +97,53 @@
     result = null;
     resultLoading = false;
     if (!id) return;
-    fetch(`/api/workflows/${encodeURIComponent(id)}`)
-      .then(async (res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const body = (await res.json()) as WorkflowDetail;
-        detail = body;
-        // Default to showing the current workflow's result.
+
+    const apply = (data: unknown) => {
+      // Server sends `null` when the workflow doesn't exist (or the dbos
+      // schema isn't provisioned yet) — surface that as an error so the
+      // page renders the same "not found" state the old REST 404 produced.
+      if (data === null) {
+        error = "workflow not found";
+        return;
+      }
+      const body = data as WorkflowDetail;
+      detail = body;
+      error = null;
+      if (!selectionSeeded) {
         const self = body.family.find((w) => w.workflow_id === body.workflow_id);
         selection = self ? { kind: "workflow", workflow: self } : null;
-      })
-      .catch((e) => {
-        error = e instanceof Error ? e.message : String(e);
-      });
+        selectionSeeded = true;
+        return;
+      }
+      // Re-point the selection at the fresh objects so the result pane sees
+      // updated has_output / has_error / status flags. Match by id; if the
+      // selected node disappears (rare — would mean a step or workflow
+      // vanished), drop selection rather than show stale data.
+      const cur = selection;
+      if (cur === null) return;
+      if (cur.kind === "workflow") {
+        const fresh = body.family.find((w) => w.workflow_id === cur.workflow.workflow_id);
+        selection = fresh ? { kind: "workflow", workflow: fresh } : null;
+      } else {
+        const fresh = body.steps.find(
+          (s) =>
+            s.workflow_id === cur.step.workflow_id && s.function_id === cur.step.function_id,
+        );
+        selection = fresh ? { kind: "step", step: fresh } : null;
+      }
+    };
+
+    workflowHandle = realtimeClient.subscribe(
+      "workflow",
+      { id },
+      {
+        onSnapshot: apply,
+        onUpdate: apply,
+        onError: (_code, message) => {
+          error = message;
+        },
+      },
+    );
   });
 
   $effect(() => {
@@ -184,6 +229,7 @@
   });
 
   onDestroy(() => {
+    workflowHandle?.dispose();
     breadcrumb.items = [];
   });
 </script>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,11 +13,20 @@ This is a stub. The authoritative architecture overview lives in the project [RE
 
 1. Argus is a separate process. It does not run inside the DBOS application and the application does not need to know Argus exists.
 2. Argus reads only from the `dbos.*` system schema. It does not own a schema, run migrations, or write to user tables.
-3. The console communicates only with the Argus backend over HTTP. There is no client-side SDK or app-side connection protocol.
+3. The console communicates only with the Argus backend over HTTP and WebSocket. There is no client-side SDK or app-side connection protocol.
+
+## Realtime layer
+
+Live updates flow over a single multiplexed WebSocket at `/ws`. The console keeps one connection open and rides it for every page; subscriptions are tagged by client-assigned `sub_id`. Server-side pollers replace the per-page `setInterval` fetches that the console used to issue.
+
+- **Channels** (`packages/server/dbos_argus/realtime/channels/`): one class per channel. `BroadcastChannel` (no params, single shared poller) covers `health`, `stats`, `schedules`. `KeyedChannel` (one poller per distinct params hash, refcounted) covers `workflows`, `workflow`, `notifications`, `stats.timeseries`.
+- **Cursor gate**: each tick runs a cheap "did anything change?" query (e.g. `(max(updated_at), count(*))`); the heavier snapshot only re-runs when the cursor advances. Pollers shut down automatically when their last subscriber disconnects.
+- **Wire protocol**: client sends `{type: "subscribe" | "unsubscribe" | "update_params" | "ping", sub_id, channel?, params?}`; server replies with `snapshot`, `update`, `error`, `ack`, or `pong`. `update_params` re-keys an existing subscription on the server without churning the client UI.
+- **Payloads**: each channel emits the same JSON shape as its REST counterpart (`/api/workflows`, `/api/workflows/{id}`, `/api/stats`, etc). REST routes remain authoritative for curl/debug — the WS layer is purely additive.
+- **Frontend**: `apps/console/src/lib/realtime/` provides a singleton `RealtimeClient` (lazy connect, exponential backoff, sub replay on reconnect, heartbeat ping/pong) and a `createSubscription<T>` helper. Pages typically `realtimeClient.subscribe(channel, params, handlers)` in `onMount` and dispose in `onDestroy`.
 
 ## Future topics (not yet documented)
 
 - Read-only queue views where DBOS exposes enough state in Postgres.
-- Live updates from server to console (likely via SSE or WebSocket) to replace polling.
 - Authentication and RBAC.
 - Deployment notes for shared dev/internal use.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:pypi": "bash scripts/build-pypi.sh",
     "dev:db": "docker compose up -d postgres && docker compose stop argus >/dev/null 2>&1 || true",
     "dev": "pnpm dev:db && ARGUS_DATABASE_URL=postgresql+asyncpg://argus:argus@localhost:5432/argus turbo run dev --filter=*",
+    "dev:sqlite": "ARGUS_DATABASE_URL=sqlite+aiosqlite:///$PWD/argus-dev.sqlite turbo run dev --filter=*",
     "lint": "turbo run lint --filter=*",
     "test": "turbo run test --filter=*",
     "check": "turbo run check --filter=*"

--- a/packages/server/dbos_argus/db/base.py
+++ b/packages/server/dbos_argus/db/base.py
@@ -79,3 +79,29 @@ class ArgusDB(ABC):
     @abstractmethod
     async def list_notifications(self, filters: NotificationFilters) -> NotificationsRows:
         """Notifications + per-destination ancestor chains, fetched together."""
+
+    # Cursors are cheap "did anything change?" probes used by the realtime
+    # layer's pollers — they gate the heavier snapshot query behind a cursor
+    # change. Each returns a comparable tuple. ("empty",) when the dbos.*
+    # schema isn't there yet (preserves the pre-connect empty state without
+    # raising). Must be orders of magnitude cheaper than the snapshot.
+
+    @abstractmethod
+    async def workflows_cursor(self) -> tuple:
+        """Coarse global probe over workflow_status + operation_outputs."""
+
+    @abstractmethod
+    async def stats_cursor(self) -> tuple:
+        """Probe for the dashboard rollup."""
+
+    @abstractmethod
+    async def schedules_cursor(self) -> tuple:
+        """Probe for the schedules list (advances on each cron tick)."""
+
+    @abstractmethod
+    async def notifications_cursor(self) -> tuple:
+        """Probe over notifications (new rows or consumed-state flips)."""
+
+    @abstractmethod
+    async def timeseries_cursor(self) -> tuple:
+        """Probe for the throughput chart (excluding the time-window tick)."""

--- a/packages/server/dbos_argus/db/postgres.py
+++ b/packages/server/dbos_argus/db/postgres.py
@@ -709,3 +709,80 @@ class PostgresArgusDB(ArgusDB):
             for ar in ancestor_rows
         ]
         return NotificationsRows(notifications=notifications, ancestors=ancestors)
+
+    async def workflows_cursor(self) -> tuple:
+        sql = """
+            SELECT
+                (SELECT MAX(updated_at) FROM dbos.workflow_status) AS max_updated,
+                (SELECT COUNT(*) FROM dbos.workflow_status) AS wf_count,
+                (SELECT COUNT(*) FROM dbos.operation_outputs) AS op_count
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except ProgrammingError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.max_updated, row.wf_count, row.op_count)
+
+    async def stats_cursor(self) -> tuple:
+        sql = """
+            SELECT
+                (SELECT COUNT(*) FROM dbos.workflow_status) AS total,
+                (SELECT MAX(updated_at) FROM dbos.workflow_status) AS max_updated,
+                (SELECT COUNT(*) FROM dbos.notifications WHERE consumed = false) AS pending
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except ProgrammingError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.total, row.max_updated, row.pending)
+
+    async def schedules_cursor(self) -> tuple:
+        sql = """
+            SELECT MAX(last_fired_at) AS max_fired, COUNT(*) AS count_all
+            FROM dbos.workflow_schedules
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except ProgrammingError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.max_fired, row.count_all)
+
+    async def notifications_cursor(self) -> tuple:
+        sql = """
+            SELECT
+                MAX(created_at_epoch_ms) AS max_created,
+                COUNT(*) AS count_all,
+                COUNT(*) FILTER (WHERE consumed = false) AS count_pending
+            FROM dbos.notifications
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except ProgrammingError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.max_created, row.count_all, row.count_pending)
+
+    async def timeseries_cursor(self) -> tuple:
+        sql = """
+            SELECT COUNT(*) AS count_all, MAX(created_at) AS max_created
+            FROM dbos.workflow_status
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except ProgrammingError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.count_all, row.max_created)

--- a/packages/server/dbos_argus/db/sqlite.py
+++ b/packages/server/dbos_argus/db/sqlite.py
@@ -785,6 +785,85 @@ class SqliteArgusDB(ArgusDB):
         ]
         return NotificationsRows(notifications=notifications, ancestors=ancestors)
 
+    async def workflows_cursor(self) -> tuple:
+        sql = """
+            SELECT
+                (SELECT MAX(updated_at) FROM workflow_status) AS max_updated,
+                (SELECT COUNT(*) FROM workflow_status) AS wf_count,
+                (SELECT COUNT(*) FROM operation_outputs) AS op_count
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except OperationalError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.max_updated, row.wf_count, row.op_count)
+
+    async def stats_cursor(self) -> tuple:
+        sql = """
+            SELECT
+                (SELECT COUNT(*) FROM workflow_status) AS total,
+                (SELECT MAX(updated_at) FROM workflow_status) AS max_updated,
+                (SELECT COUNT(*) FROM notifications WHERE consumed = 0) AS pending
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except OperationalError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.total, row.max_updated, row.pending)
+
+    async def schedules_cursor(self) -> tuple:
+        sql = """
+            SELECT MAX(last_fired_at) AS max_fired, COUNT(*) AS count_all
+            FROM workflow_schedules
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except OperationalError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.max_fired, row.count_all)
+
+    async def notifications_cursor(self) -> tuple:
+        # SQLite has no FILTER (WHERE …) clause; fold into a CASE SUM.
+        sql = """
+            SELECT
+                MAX(created_at_epoch_ms) AS max_created,
+                COUNT(*) AS count_all,
+                SUM(CASE WHEN consumed = 0 THEN 1 ELSE 0 END) AS count_pending
+            FROM notifications
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except OperationalError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        # SUM over no rows is NULL in SQLite; coerce to 0 for a clean tuple.
+        return (row.max_created, row.count_all, row.count_pending or 0)
+
+    async def timeseries_cursor(self) -> tuple:
+        sql = """
+            SELECT COUNT(*) AS count_all, MAX(created_at) AS max_created
+            FROM workflow_status
+        """
+        try:
+            async with self.engine.connect() as conn:
+                row = (await conn.execute(text(sql))).fetchone()
+        except OperationalError:
+            return ("empty",)
+        if row is None:
+            return ("empty",)
+        return (row.count_all, row.max_created)
+
 
 def _dfs_grouped(rows) -> list[WorkflowListRow]:
     """Convert flat (parent_id, root_uuid, root_updated_at, depth, …) rows

--- a/packages/server/dbos_argus/main.py
+++ b/packages/server/dbos_argus/main.py
@@ -15,8 +15,14 @@ from . import __version__
 from .db import db
 from .db.rows import (
     NotificationFilters,
+    NotificationsRows,
+    ScheduleRow,
+    StatsRow,
     StepRow,
+    ThroughputRow,
+    WorkflowDetailRows,
     WorkflowFilters,
+    WorkflowListRow,
 )
 from .decoding import decode_dbos_value
 from .schema_dump import load_full_dump
@@ -59,6 +65,38 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# Realtime layer wiring is below the route bodies — channels lazy-import the
+# `fetch_*` helpers above to break the circular dep with this module.
+def _setup_realtime() -> None:
+    if not settings.realtime_enabled:
+        logger.info("realtime layer disabled (ARGUS_REALTIME_ENABLED=false)")
+        return
+    from .realtime import RealtimeHub, register_websocket_route
+    from .realtime.channels import (
+        HealthChannel,
+        NotificationsChannel,
+        SchedulesChannel,
+        StatsChannel,
+        StatsTimeseriesChannel,
+        WorkflowChannel,
+        WorkflowsChannel,
+    )
+
+    hub = RealtimeHub(
+        default_interval_ms=settings.realtime_interval_ms,
+        max_subs_per_conn=settings.realtime_max_subs_per_conn,
+    )
+    hub.register_channel(HealthChannel(), interval_ms=settings.realtime_health_interval_ms)
+    hub.register_channel(StatsChannel())
+    hub.register_channel(StatsTimeseriesChannel())
+    hub.register_channel(WorkflowsChannel())
+    hub.register_channel(WorkflowChannel())
+    hub.register_channel(SchedulesChannel())
+    hub.register_channel(NotificationsChannel())
+    register_websocket_route(app, hub, allowed_origins=settings.cors_origins_list)
+    app.state.realtime_hub = hub
 
 
 @app.get("/healthz")
@@ -146,6 +184,32 @@ class WorkflowListItem(BaseModel):
     operation_count: int
 
 
+# Pure mapper from a list-row dataclass to the public Pydantic model. Shared
+# by the REST route and the realtime `workflows` channel so the wire shape
+# stays identical across transports.
+def _to_workflow_list_item(r: WorkflowListRow) -> WorkflowListItem:
+    return WorkflowListItem(
+        workflow_id=r.workflow_uuid,
+        parent_workflow_id=r.parent_workflow_id,
+        name=r.name,
+        status=r.status,
+        queue_name=r.queue_name,
+        executor_id=r.executor_id,
+        priority=r.priority or 0,
+        started_at=datetime.fromtimestamp(r.started_ms / 1000, tz=UTC),
+        updated_at=datetime.fromtimestamp(r.updated_ms / 1000, tz=UTC),
+        depth=r.depth,
+        operation_count=r.op_count,
+    )
+
+
+async def fetch_workflow_list(filters: WorkflowFilters) -> list[WorkflowListItem]:
+    """Run the workflow-list query and return Pydantic models. Used by the
+    REST route and the realtime channel."""
+    rows = await db.list_workflows(filters)
+    return [_to_workflow_list_item(r) for r in rows]
+
+
 @app.get("/api/workflows")
 async def list_workflows(
     limit: int = Query(default=50, ge=1, le=200),
@@ -167,23 +231,7 @@ async def list_workflows(
         hide_scheduled=hide_scheduled,
         grouped=grouped,
     )
-    rows = await db.list_workflows(filters)
-    return [
-        WorkflowListItem(
-            workflow_id=r.workflow_uuid,
-            parent_workflow_id=r.parent_workflow_id,
-            name=r.name,
-            status=r.status,
-            queue_name=r.queue_name,
-            executor_id=r.executor_id,
-            priority=r.priority or 0,
-            started_at=datetime.fromtimestamp(r.started_ms / 1000, tz=UTC),
-            updated_at=datetime.fromtimestamp(r.updated_ms / 1000, tz=UTC),
-            depth=r.depth,
-            operation_count=r.op_count,
-        )
-        for r in rows
-    ]
+    return await fetch_workflow_list(filters)
 
 
 class WorkflowStep(BaseModel):
@@ -324,11 +372,12 @@ def _sleep_requested_ms(step: StepRow) -> int | None:
 # Walks up parent_workflow_id to find the topmost ancestor (or the workflow
 # itself if it has no parent), then expands that ancestor's whole subtree in
 # DFS order — matching how the list endpoint groups trees.
-@app.get("/api/workflows/{workflow_id}")
-async def get_workflow(workflow_id: str) -> WorkflowDetail:
-    detail = await db.get_workflow_detail(workflow_id)
+def _build_workflow_detail(detail: WorkflowDetailRows, workflow_id: str) -> WorkflowDetail | None:
+    """Map adapter rows to the detail Pydantic model. Returns None when the
+    family is empty (workflow not found) — callers translate that to a 404
+    or an empty snapshot, depending on transport."""
     if not detail.family:
-        raise HTTPException(status_code=404, detail="workflow not found")
+        return None
 
     family = [
         WorkflowFamilyItem(
@@ -405,7 +454,9 @@ async def get_workflow(workflow_id: str) -> WorkflowDetail:
             )
     events = list(events_by_key.values())
 
-    self_item = next(w for w in family if w.workflow_id == workflow_id)
+    self_item = next((w for w in family if w.workflow_id == workflow_id), None)
+    if self_item is None:
+        return None
     return WorkflowDetail(
         workflow_id=self_item.workflow_id,
         parent_workflow_id=self_item.parent_workflow_id,
@@ -417,6 +468,21 @@ async def get_workflow(workflow_id: str) -> WorkflowDetail:
         steps=steps,
         events=events,
     )
+
+
+async def fetch_workflow_detail(workflow_id: str) -> WorkflowDetail | None:
+    """Run the workflow-detail query and map to the Pydantic model. Returns
+    None when the workflow doesn't exist."""
+    detail = await db.get_workflow_detail(workflow_id)
+    return _build_workflow_detail(detail, workflow_id)
+
+
+@app.get("/api/workflows/{workflow_id}")
+async def get_workflow(workflow_id: str) -> WorkflowDetail:
+    result = await fetch_workflow_detail(workflow_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="workflow not found")
+    return result
 
 
 # Lazily fetches the output/error payload for a single workflow row. Split out
@@ -464,10 +530,7 @@ class DashboardStats(BaseModel):
     active_schedules: int
 
 
-@app.get("/api/stats")
-async def get_stats() -> DashboardStats:
-    since_ms = int(datetime.now(UTC).timestamp() * 1000) - 86_400_000
-    row = await db.get_stats(since_ms)
+def _to_dashboard_stats(row: StatsRow) -> DashboardStats:
     return DashboardStats(
         total=row.total,
         in_flight=row.in_flight,
@@ -476,6 +539,16 @@ async def get_stats() -> DashboardStats:
         pending_notifications=row.pending_notifications,
         active_schedules=row.active_schedules,
     )
+
+
+async def fetch_stats() -> DashboardStats:
+    since_ms = int(datetime.now(UTC).timestamp() * 1000) - 86_400_000
+    return _to_dashboard_stats(await db.get_stats(since_ms))
+
+
+@app.get("/api/stats")
+async def get_stats() -> DashboardStats:
+    return await fetch_stats()
 
 
 class ThroughputBucket(BaseModel):
@@ -495,14 +568,7 @@ _THROUGHPUT_RANGES: dict[str, tuple[Literal["hour", "day"], int]] = {
 }
 
 
-@app.get("/api/stats/timeseries")
-async def get_throughput(
-    range: Literal["24h", "7d", "30d"] = "7d",
-) -> list[ThroughputBucket]:
-    bucket, lookback_ms = _THROUGHPUT_RANGES[range]
-    until_ms = int(datetime.now(UTC).timestamp() * 1000)
-    since_ms = until_ms - lookback_ms
-    rows = await db.get_throughput(since_ms=since_ms, until_ms=until_ms, bucket=bucket)
+def _to_throughput_buckets(rows: list[ThroughputRow]) -> list[ThroughputBucket]:
     return [
         ThroughputBucket(
             ts=r.ts,
@@ -512,6 +578,21 @@ async def get_throughput(
         )
         for r in rows
     ]
+
+
+async def fetch_throughput(range_: Literal["24h", "7d", "30d"]) -> list[ThroughputBucket]:
+    bucket, lookback_ms = _THROUGHPUT_RANGES[range_]
+    until_ms = int(datetime.now(UTC).timestamp() * 1000)
+    since_ms = until_ms - lookback_ms
+    rows = await db.get_throughput(since_ms=since_ms, until_ms=until_ms, bucket=bucket)
+    return _to_throughput_buckets(rows)
+
+
+@app.get("/api/stats/timeseries")
+async def get_throughput(
+    range: Literal["24h", "7d", "30d"] = "7d",
+) -> list[ThroughputBucket]:
+    return await fetch_throughput(range)
 
 
 class WorkflowSchedule(BaseModel):
@@ -527,24 +608,29 @@ class WorkflowSchedule(BaseModel):
     queue_name: str | None
 
 
+def _to_workflow_schedule(r: ScheduleRow) -> WorkflowSchedule:
+    return WorkflowSchedule(
+        schedule_id=r.schedule_id,
+        schedule_name=r.schedule_name,
+        workflow_name=r.workflow_name,
+        workflow_class_name=r.workflow_class_name,
+        schedule=r.schedule,
+        status=r.status,
+        last_fired_at=r.last_fired_at,
+        automatic_backfill=r.automatic_backfill,
+        cron_timezone=r.cron_timezone,
+        queue_name=r.queue_name,
+    )
+
+
+async def fetch_schedules() -> list[WorkflowSchedule]:
+    rows = await db.list_schedules()
+    return [_to_workflow_schedule(r) for r in rows]
+
+
 @app.get("/api/schedules")
 async def list_schedules() -> list[WorkflowSchedule]:
-    rows = await db.list_schedules()
-    return [
-        WorkflowSchedule(
-            schedule_id=r.schedule_id,
-            schedule_name=r.schedule_name,
-            workflow_name=r.workflow_name,
-            workflow_class_name=r.workflow_class_name,
-            schedule=r.schedule,
-            status=r.status,
-            last_fired_at=r.last_fired_at,
-            automatic_backfill=r.automatic_backfill,
-            cron_timezone=r.cron_timezone,
-            queue_name=r.queue_name,
-        )
-        for r in rows
-    ]
+    return await fetch_schedules()
 
 
 class WorkflowAncestor(BaseModel):
@@ -568,21 +654,7 @@ class NotificationItem(BaseModel):
     destination_ancestors: list[WorkflowAncestor]
 
 
-@app.get("/api/notifications")
-async def list_notifications(
-    consumed: bool | None = None,
-    destination_uuid: str | None = None,
-    topic: str | None = None,
-    limit: int = Query(default=200, ge=1, le=500),
-) -> list[NotificationItem]:
-    result = await db.list_notifications(
-        NotificationFilters(
-            limit=limit,
-            consumed=consumed,
-            destination_uuid=destination_uuid,
-            topic=topic,
-        )
-    )
+def _to_notification_items(result: NotificationsRows) -> list[NotificationItem]:
     ancestors_by_seed: dict[str, list[WorkflowAncestor]] = {}
     for ar in result.ancestors:
         ancestors_by_seed.setdefault(ar.seed_id, []).append(
@@ -602,6 +674,33 @@ async def list_notifications(
         )
         for r in result.notifications
     ]
+
+
+async def fetch_notifications(filters: NotificationFilters) -> list[NotificationItem]:
+    result = await db.list_notifications(filters)
+    return _to_notification_items(result)
+
+
+@app.get("/api/notifications")
+async def list_notifications(
+    consumed: bool | None = None,
+    destination_uuid: str | None = None,
+    topic: str | None = None,
+    limit: int = Query(default=200, ge=1, le=500),
+) -> list[NotificationItem]:
+    return await fetch_notifications(
+        NotificationFilters(
+            limit=limit,
+            consumed=consumed,
+            destination_uuid=destination_uuid,
+            topic=topic,
+        )
+    )
+
+
+# Wire the WebSocket route before the SPA catch-all below — the catch-all
+# `/{full_path:path}` would otherwise match `/ws` first.
+_setup_realtime()
 
 
 # Default to the SPA bundled inside the wheel at dbos_argus/_console/. Override

--- a/packages/server/dbos_argus/realtime/__init__.py
+++ b/packages/server/dbos_argus/realtime/__init__.py
@@ -1,0 +1,32 @@
+"""Realtime (WebSocket) layer.
+
+Server-side pollers query DBOS system tables on a tick, gate on a cheap
+cursor (e.g. `max(updated_at), count(*)`), and fan out snapshots to subscribed
+clients over a single multiplexed `/ws` endpoint.
+
+Architecture:
+- `protocol`: Pydantic models for the wire format.
+- `channel`: base `Channel` + `BroadcastChannel` (one shared poller per
+  channel) and `KeyedChannel` (one poller per distinct params hash).
+- `hub`: `RealtimeHub` tracks connections, subscriptions, and channel
+  registry; routes incoming client messages.
+- `endpoint`: FastAPI WebSocket route bound to a hub.
+
+REST endpoints stay around for direct/curl access; the `/ws` layer is a
+parallel push channel, not a replacement.
+"""
+
+from .channel import BroadcastChannel, Channel, KeyedChannel
+from .endpoint import register_websocket_route
+from .hub import RealtimeHub
+from .protocol import ClientMessage, ServerMessage
+
+__all__ = [
+    "BroadcastChannel",
+    "Channel",
+    "ClientMessage",
+    "KeyedChannel",
+    "RealtimeHub",
+    "ServerMessage",
+    "register_websocket_route",
+]

--- a/packages/server/dbos_argus/realtime/channel.py
+++ b/packages/server/dbos_argus/realtime/channel.py
@@ -1,0 +1,82 @@
+"""Channel abstractions.
+
+A `Channel` produces snapshots for clients. There are two flavors:
+
+- `BroadcastChannel`: one poller per channel; identical payload to every
+  subscriber (e.g. `health`, `stats` — no params, single source of truth).
+- `KeyedChannel`: one poller per distinct params hash; subscribers with the
+  same params share a poller (e.g. `workflows` filtered by status, `workflow`
+  by id).
+
+Both use a two-phase poll: a cheap `cursor` query gates the heavier
+`snapshot` query so the DB stays cool when nothing changed.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import Any
+
+# Sentinel returned by `cursor()` when the channel can't compute a cheap
+# change-detect (e.g. `health`). Any callsite that gets `None` should treat
+# the channel as "always changed" and re-snapshot every tick.
+NoCursor = None
+
+
+class Channel(ABC):
+    """Base channel. Subclasses are typically `BroadcastChannel` or
+    `KeyedChannel` — directly subclassing `Channel` is unusual.
+    """
+
+    name: str
+
+    @abstractmethod
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        """Compute the full payload for this channel + params."""
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        """Cheap change-detect signal. Default: `None` (always re-snapshot)."""
+        return NoCursor
+
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Override to coerce / validate client-supplied params before use.
+
+        Default returns params unchanged. Raise `ValueError` on bad input —
+        the hub turns it into an `error` message back to the client.
+        """
+        return params
+
+
+class BroadcastChannel(Channel):
+    """A channel with no params — every subscriber sees the same payload.
+
+    Examples: `health`, `stats`. The hub keeps exactly one poller per
+    BroadcastChannel and fans the cached snapshot out to all subscribers.
+    """
+
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
+        if params:
+            raise ValueError(f"channel '{self.name}' does not accept params")
+        return None
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return NoCursor
+
+
+class KeyedChannel(Channel):
+    """A channel where params identify a sub-poller.
+
+    The hub maintains one poller per `(channel.name, params_key)` and
+    refcounts them — pollers shut down when their last subscriber leaves.
+    Subclasses usually override `params_key` only if their params dict has
+    keys whose JSON ordering isn't stable (rare; default is `sort_keys=True`).
+    """
+
+    def params_key(self, params: dict[str, Any] | None) -> str:
+        """Stable hash of params used as the poller key."""
+        if params is None:
+            return ""
+        # `default=str` lets us serialize datetime / Decimal etc. without
+        # caring; the result is just an opaque key, not a payload.
+        return json.dumps(params, sort_keys=True, default=str)

--- a/packages/server/dbos_argus/realtime/channels/__init__.py
+++ b/packages/server/dbos_argus/realtime/channels/__init__.py
@@ -1,0 +1,25 @@
+"""Concrete realtime channels.
+
+One module per channel. Each module exports a class subclassing
+`BroadcastChannel` or `KeyedChannel` and produces the same payload shape as
+its REST counterpart so clients can swap between transports without a
+schema-translation layer.
+"""
+
+from .health import HealthChannel
+from .notifications import NotificationsChannel
+from .schedules import SchedulesChannel
+from .stats import StatsChannel
+from .timeseries import StatsTimeseriesChannel
+from .workflow import WorkflowChannel
+from .workflows import WorkflowsChannel
+
+__all__ = [
+    "HealthChannel",
+    "NotificationsChannel",
+    "SchedulesChannel",
+    "StatsChannel",
+    "StatsTimeseriesChannel",
+    "WorkflowChannel",
+    "WorkflowsChannel",
+]

--- a/packages/server/dbos_argus/realtime/channels/health.py
+++ b/packages/server/dbos_argus/realtime/channels/health.py
@@ -1,0 +1,42 @@
+"""`health` channel — pushes the same payload shape as `GET /healthz`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...db import db
+from ..channel import BroadcastChannel
+
+
+class HealthChannel(BroadcastChannel):
+    name = "health"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        # Hash on the result of the snapshot itself — health probes are cheap
+        # enough that we don't need a separate "did anything change?" query.
+        # Returning `NoCursor` from the base class would also work; this just
+        # lets us de-dupe `update` broadcasts when the DB stays up.
+        return await self._snapshot()
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Cursor already produced the payload; recompute to keep the API
+        # symmetrical with other channels (cursor is meant to be cheap, but
+        # our cursor IS the snapshot here, so we just call it again).
+        return await self._snapshot()
+
+    async def _snapshot(self) -> dict[str, str]:
+        db_up = True
+        db_error: str | None = None
+        try:
+            await db.healthcheck()
+        except Exception as e:
+            db_up = False
+            db_error = str(e)
+        body: dict[str, str] = {
+            "status": "ok" if db_up else "degraded",
+            "database": "up" if db_up else "down",
+            "database_url": db.display_url,
+        }
+        if db_error is not None:
+            body["database_error"] = db_error
+        return body

--- a/packages/server/dbos_argus/realtime/channels/notifications.py
+++ b/packages/server/dbos_argus/realtime/channels/notifications.py
@@ -1,0 +1,75 @@
+"""`notifications` channel — pushes the same payload shape as `GET /api/notifications`.
+
+Params (all optional):
+  - consumed: bool | None
+  - destination_uuid: str | None
+  - topic: str | None
+  - limit: int (1..500, default 200)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...db import db
+from ...db.rows import NotificationFilters
+from ..channel import KeyedChannel
+
+_ALLOWED_PARAM_KEYS = {"consumed", "destination_uuid", "topic", "limit"}
+
+
+def _normalize(params: dict[str, Any] | None) -> dict[str, Any]:
+    raw = params or {}
+    unknown = set(raw) - _ALLOWED_PARAM_KEYS
+    if unknown:
+        raise ValueError(f"unknown params: {sorted(unknown)}")
+
+    consumed = raw.get("consumed")
+    if consumed is not None and not isinstance(consumed, bool):
+        raise ValueError("consumed must be a bool")
+
+    destination_uuid = raw.get("destination_uuid")
+    if destination_uuid is not None and not isinstance(destination_uuid, str):
+        raise ValueError("destination_uuid must be a string")
+
+    topic = raw.get("topic")
+    if topic is not None and not isinstance(topic, str):
+        raise ValueError("topic must be a string")
+
+    limit = raw.get("limit", 200)
+    if not isinstance(limit, int) or limit < 1 or limit > 500:
+        raise ValueError("limit must be an int in 1..500")
+
+    return {
+        "consumed": consumed,
+        "destination_uuid": destination_uuid or None,
+        "topic": topic or None,
+        "limit": limit,
+    }
+
+
+class NotificationsChannel(KeyedChannel):
+    name = "notifications"
+
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
+        return _normalize(params)
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        # Coarse global probe: per-filter aggregates would be close to
+        # snapshot work, so we accept slight over-snapshotting.
+        return await db.notifications_cursor()
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Lazy import to break the realtime → main → realtime cycle.
+        from ...main import fetch_notifications
+
+        normalized = params or {}
+        items = await fetch_notifications(
+            NotificationFilters(
+                limit=normalized.get("limit", 200),
+                consumed=normalized.get("consumed"),
+                destination_uuid=normalized.get("destination_uuid"),
+                topic=normalized.get("topic"),
+            )
+        )
+        return [it.model_dump(mode="json") for it in items]

--- a/packages/server/dbos_argus/realtime/channels/schedules.py
+++ b/packages/server/dbos_argus/realtime/channels/schedules.py
@@ -1,0 +1,22 @@
+"""`schedules` channel — pushes the same payload shape as `GET /api/schedules`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...db import db
+from ..channel import BroadcastChannel
+
+
+class SchedulesChannel(BroadcastChannel):
+    name = "schedules"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return await db.schedules_cursor()
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Lazy import to break the realtime → main → realtime cycle.
+        from ...main import fetch_schedules
+
+        items = await fetch_schedules()
+        return [it.model_dump(mode="json") for it in items]

--- a/packages/server/dbos_argus/realtime/channels/stats.py
+++ b/packages/server/dbos_argus/realtime/channels/stats.py
@@ -1,0 +1,26 @@
+"""`stats` channel — pushes the same payload shape as `GET /api/stats`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...db import db
+from ..channel import BroadcastChannel
+
+
+class StatsChannel(BroadcastChannel):
+    name = "stats"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        # Cheap COUNT + max(updated_at) over workflow_status, plus the
+        # unconsumed-notification count. If none of these moved, the rollup
+        # didn't change either. (active_schedules can drift on its own but
+        # changes rarely; a dashboard reader is fine waiting for the next
+        # workflow event to refresh.)
+        return await db.stats_cursor()
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Lazy import to break the realtime → main → realtime cycle.
+        from ...main import fetch_stats
+
+        return (await fetch_stats()).model_dump(mode="json")

--- a/packages/server/dbos_argus/realtime/channels/timeseries.py
+++ b/packages/server/dbos_argus/realtime/channels/timeseries.py
@@ -1,0 +1,46 @@
+"""`stats.timeseries` channel — pushes `GET /api/stats/timeseries` payloads.
+
+Params: `{range: "24h" | "7d" | "30d"}` — defaults to "7d".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal, cast
+
+from ...db import db
+from ..channel import KeyedChannel
+
+_VALID_RANGES = {"24h", "7d", "30d"}
+
+
+class StatsTimeseriesChannel(KeyedChannel):
+    # Uses a dotted name to nest under `stats` semantically without nesting
+    # actual modules. Clients subscribe by `channel: "stats.timeseries"`.
+    name = "stats.timeseries"
+
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
+        raw = params or {}
+        unknown = set(raw) - {"range"}
+        if unknown:
+            raise ValueError(f"unknown params: {sorted(unknown)}")
+        rng = raw.get("range", "7d")
+        if rng not in _VALID_RANGES:
+            raise ValueError(f"range must be one of {sorted(_VALID_RANGES)}")
+        return {"range": rng}
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        # Coarse signal — bucket counts can only change when workflow_status
+        # rows arrive. Layer a minute-level tick on top so the bucket window
+        # rolls forward even when no new workflows arrive.
+        minute_tick = int(datetime.now(UTC).timestamp() // 60)
+        base = await db.timeseries_cursor()
+        return (*base, minute_tick)
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Lazy import to break the realtime → main → realtime cycle.
+        from ...main import fetch_throughput
+
+        rng = (params or {}).get("range", "7d")
+        items = await fetch_throughput(cast(Literal["24h", "7d", "30d"], rng))
+        return [it.model_dump(mode="json") for it in items]

--- a/packages/server/dbos_argus/realtime/channels/workflow.py
+++ b/packages/server/dbos_argus/realtime/channels/workflow.py
@@ -1,0 +1,37 @@
+"""`workflow` channel — pushes the same payload shape as `GET /api/workflows/{id}`.
+
+Params: `{id: string}` — required.
+
+There's no cheap cursor here: the snapshot itself is the family walk + steps
++ events. Computing a "did anything in this family change?" probe would do
+almost the same work. We just re-snapshot every tick; per-page subscribers
+are few (one client per detail page).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..channel import KeyedChannel
+
+
+class WorkflowChannel(KeyedChannel):
+    name = "workflow"
+
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not params or not isinstance(params.get("id"), str) or not params["id"].strip():
+            raise ValueError("workflow channel requires params.id (non-empty string)")
+        return {"id": params["id"]}
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Lazy import to break the realtime → main → realtime cycle.
+        from ...main import fetch_workflow_detail
+
+        workflow_id = (params or {}).get("id")
+        result = await fetch_workflow_detail(str(workflow_id))
+        if result is None:
+            # Surface "not found" as an empty snapshot so the client can render
+            # an empty state. The frontend already has to handle this for
+            # first-paint races.
+            return None
+        return result.model_dump(mode="json")

--- a/packages/server/dbos_argus/realtime/channels/workflows.py
+++ b/packages/server/dbos_argus/realtime/channels/workflows.py
@@ -1,0 +1,134 @@
+"""`workflows` channel — pushes the same payload shape as `GET /api/workflows`.
+
+Params accepted (all optional):
+  - limit: int (1..200, default 50)
+  - q: str | None
+  - started_after: ISO-8601 string | epoch-ms int | None
+  - started_before: ISO-8601 string | epoch-ms int | None
+  - status: list[str] | None
+  - queue_name: str | None
+  - grouped: bool (default true)
+  - hide_scheduled: bool (default false)
+
+The cursor is a coarse "did anything in the workflow space change?" probe
+over the entire `workflow_status` + `operation_outputs` tables rather than a
+per-filter aggregate. That's a small over-snapshot when multiple narrow
+filters are subscribed concurrently, but the cursor query is two indexed
+COUNTs + a MAX — orders of magnitude cheaper than re-running the recursive
+walk that backs the snapshot.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from ...db import db
+from ...db.rows import WorkflowFilters
+from ..channel import KeyedChannel
+
+_ALLOWED_PARAM_KEYS = {
+    "limit",
+    "q",
+    "started_after",
+    "started_before",
+    "status",
+    "queue_name",
+    "grouped",
+    "hide_scheduled",
+}
+
+
+def _coerce_epoch_ms(value: Any) -> int | None:
+    """Accept either an int (epoch ms) or an ISO-8601 string and return ms."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        # Accept the same shapes FastAPI parses for `datetime` query params.
+        try:
+            return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
+        except ValueError as e:
+            raise ValueError(f"invalid datetime: {value!r}") from e
+    raise ValueError(f"expected int or ISO-8601 string, got {type(value).__name__}")
+
+
+def _normalize(params: dict[str, Any] | None) -> dict[str, Any]:
+    """Validate + normalize client params into a stable dict that maps 1-to-1
+    to `WorkflowFilters` kwargs. Returned dict is also the params_key source,
+    so equivalent client payloads (status omitted vs. status=null) collapse
+    to the same poller.
+    """
+    raw = params or {}
+    unknown = set(raw) - _ALLOWED_PARAM_KEYS
+    if unknown:
+        raise ValueError(f"unknown params: {sorted(unknown)}")
+
+    limit_raw = raw.get("limit", 50)
+    if not isinstance(limit_raw, int) or limit_raw < 1 or limit_raw > 200:
+        raise ValueError("limit must be an int in 1..200")
+
+    q_raw = raw.get("q")
+    q = q_raw.strip() if isinstance(q_raw, str) and q_raw.strip() else None
+
+    statuses_raw = raw.get("status")
+    if statuses_raw is None:
+        statuses = None
+    elif isinstance(statuses_raw, list) and all(isinstance(s, str) for s in statuses_raw):
+        statuses = statuses_raw if statuses_raw else None
+    else:
+        raise ValueError("status must be a list of strings")
+
+    queue_name = raw.get("queue_name")
+    if queue_name is not None and not isinstance(queue_name, str):
+        raise ValueError("queue_name must be a string")
+
+    grouped = raw.get("grouped", True)
+    if not isinstance(grouped, bool):
+        raise ValueError("grouped must be a bool")
+
+    hide_scheduled = raw.get("hide_scheduled", False)
+    if not isinstance(hide_scheduled, bool):
+        raise ValueError("hide_scheduled must be a bool")
+
+    return {
+        "limit": limit_raw,
+        "q": q,
+        "started_after_ms": _coerce_epoch_ms(raw.get("started_after")),
+        "started_before_ms": _coerce_epoch_ms(raw.get("started_before")),
+        "statuses": statuses,
+        "queue_name": queue_name,
+        "grouped": grouped,
+        "hide_scheduled": hide_scheduled,
+    }
+
+
+class WorkflowsChannel(KeyedChannel):
+    name = "workflows"
+
+    def validate_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
+        return _normalize(params)
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return await db.workflows_cursor()
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        # Lazy import to break the realtime → main → realtime cycle.
+        from ...main import fetch_workflow_list
+
+        normalized = params or {}
+        filters = WorkflowFilters(
+            limit=normalized.get("limit", 50),
+            q=normalized.get("q"),
+            started_after_ms=normalized.get("started_after_ms"),
+            started_before_ms=normalized.get("started_before_ms"),
+            statuses=normalized.get("statuses"),
+            queue_name=normalized.get("queue_name"),
+            hide_scheduled=normalized.get("hide_scheduled", False),
+            grouped=normalized.get("grouped", True),
+        )
+        items = await fetch_workflow_list(filters)
+        # JSON mode so datetimes round-trip as ISO strings, matching the REST
+        # endpoint's response shape exactly.
+        return [it.model_dump(mode="json") for it in items]

--- a/packages/server/dbos_argus/realtime/endpoint.py
+++ b/packages/server/dbos_argus/realtime/endpoint.py
@@ -1,0 +1,126 @@
+"""FastAPI WebSocket route bound to a `RealtimeHub`."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from .hub import Connection, RealtimeHub
+from .protocol import (
+    ErrorMessage,
+    PongMessage,
+    ServerMessage,
+)
+
+logger = logging.getLogger("dbos_argus.realtime")
+
+
+def _origin_allowed(origin: str | None, allowed: list[str]) -> bool:
+    """Strict origin check.
+
+    `allowed` comes from `cors_origins_list`. An empty list (or a "*" entry)
+    permits any origin — same trust model as the REST CORS middleware.
+    Missing Origin header is allowed because non-browser clients (curl,
+    test runners, MCP) don't send one.
+    """
+    if not allowed or "*" in allowed:
+        return True
+    if origin is None:
+        return True
+    return origin in allowed
+
+
+def register_websocket_route(
+    app: FastAPI, hub: RealtimeHub, *, path: str = "/ws", allowed_origins: list[str] | None = None
+) -> None:
+    allowed = list(allowed_origins or [])
+
+    @app.websocket(path)
+    async def ws_endpoint(websocket: WebSocket) -> None:  # pragma: no cover - thin glue
+        origin = websocket.headers.get("origin")
+        if not _origin_allowed(origin, allowed):
+            await websocket.close(code=1008, reason="origin not allowed")
+            return
+
+        await websocket.accept()
+        conn = Connection(websocket=websocket)
+        hub.attach(conn)
+        writer = asyncio.create_task(_writer(conn), name="ws:writer")
+
+        try:
+            while True:
+                msg = await websocket.receive_json()
+                await _handle_client_message(hub, conn, msg)
+        except WebSocketDisconnect:
+            pass
+        except Exception as e:
+            logger.warning("realtime: ws receive error: %s", e)
+        finally:
+            hub.detach(conn)
+            writer.cancel()
+            try:
+                await writer
+            except asyncio.CancelledError:
+                pass
+
+
+async def _writer(conn: Connection) -> None:
+    """Drain the connection's outbound queue to the websocket.
+
+    Runs as its own task so a slow client can't block hub broadcasts.
+    """
+    try:
+        while True:
+            msg: ServerMessage = await conn.out_queue.get()
+            await conn.websocket.send_json(msg.model_dump())
+    except WebSocketDisconnect:
+        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("realtime: ws writer error: %s", e)
+
+
+async def _handle_client_message(hub: RealtimeHub, conn: Connection, msg: Any) -> None:
+    if not isinstance(msg, dict):
+        conn.enqueue(ErrorMessage(code="bad_message", message="expected JSON object"))
+        return
+    msg_type = msg.get("type")
+
+    if msg_type == "ping":
+        conn.enqueue(PongMessage())
+        return
+
+    if msg_type == "subscribe":
+        sub_id = msg.get("sub_id")
+        channel = msg.get("channel")
+        params = msg.get("params")
+        if not isinstance(sub_id, str) or not isinstance(channel, str):
+            conn.enqueue(
+                ErrorMessage(code="bad_message", message="subscribe requires sub_id + channel")
+            )
+            return
+        hub.subscribe(conn, sub_id, channel, params if isinstance(params, dict) else None)
+        return
+
+    if msg_type == "unsubscribe":
+        sub_id = msg.get("sub_id")
+        if not isinstance(sub_id, str):
+            conn.enqueue(ErrorMessage(code="bad_message", message="unsubscribe requires sub_id"))
+            return
+        hub.unsubscribe(conn, sub_id)
+        return
+
+    if msg_type == "update_params":
+        sub_id = msg.get("sub_id")
+        params = msg.get("params")
+        if not isinstance(sub_id, str):
+            conn.enqueue(ErrorMessage(code="bad_message", message="update_params requires sub_id"))
+            return
+        hub.update_params(conn, sub_id, params if isinstance(params, dict) else None)
+        return
+
+    conn.enqueue(ErrorMessage(code="unknown_type", message=f"unknown message type: {msg_type!r}"))

--- a/packages/server/dbos_argus/realtime/hub.py
+++ b/packages/server/dbos_argus/realtime/hub.py
@@ -204,9 +204,16 @@ class Poller:
 
             self._last_error = None
             had_snapshot = self.has_snapshot
+            prev_snapshot = self._last_snapshot
             self._last_cursor = cursor
             self._last_snapshot = snapshot
             if had_snapshot:
+                if snapshot == prev_snapshot:
+                    # Cursor-less channels (workflow, health) re-snapshot every
+                    # tick; suppress the update when the payload is identical so
+                    # clients don't re-render needlessly. xyflow in particular
+                    # restarts edge-dash animations on every props update.
+                    continue
                 self._broadcast_update()
             else:
                 # First snapshot for this poller — broadcast as `snapshot`.

--- a/packages/server/dbos_argus/realtime/hub.py
+++ b/packages/server/dbos_argus/realtime/hub.py
@@ -1,0 +1,393 @@
+"""Hub, Connection, Subscription, Poller.
+
+The hub owns the channel registry and maps each subscription to a `Poller`.
+Pollers hold a refcounted set of subscriptions; when the last subscriber
+leaves, the poller's loop is cancelled and removed from the hub.
+
+Connections own a bounded outbound queue served by a writer task — a slow
+or hung client will fill its queue and get force-closed without blocking
+any poller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from .channel import BroadcastChannel, Channel, KeyedChannel, NoCursor
+from .protocol import (
+    AckMessage,
+    ErrorMessage,
+    ServerMessage,
+    SnapshotMessage,
+    UpdateMessage,
+)
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+logger = logging.getLogger("dbos_argus.realtime")
+
+
+# Per-connection outbound queue. Sized so a healthy client never sees backpressure
+# (each poller emits at most ~one message per tick), but small enough that a
+# stuck client gets disconnected promptly instead of bloating server memory.
+_OUTBOUND_QUEUE_LIMIT = 128
+
+
+# `eq=False` keeps these identity-hashable so the hub can store them in
+# `set`s and `dict`s. The dataclass-generated `__eq__` would set
+# `__hash__ = None`, which we don't want for these mutable bookkeeping types.
+@dataclass(eq=False)
+class Subscription:
+    sub_id: str
+    channel: Channel
+    params: dict[str, Any] | None
+    connection: Connection
+    poller: Poller | None = None
+
+
+def _make_out_queue() -> asyncio.Queue[ServerMessage]:
+    return asyncio.Queue(_OUTBOUND_QUEUE_LIMIT)
+
+
+@dataclass(eq=False)
+class Connection:
+    websocket: WebSocket
+    subs: dict[str, Subscription] = field(default_factory=dict)
+    out_queue: asyncio.Queue[ServerMessage] = field(default_factory=_make_out_queue)
+    closed: bool = False
+
+    def enqueue(self, msg: ServerMessage) -> bool:
+        """Try to enqueue `msg` for sending. Returns False if the queue is
+        full — caller should close the connection rather than block.
+        """
+        if self.closed:
+            return False
+        try:
+            self.out_queue.put_nowait(msg)
+            return True
+        except asyncio.QueueFull:
+            return False
+
+
+class Poller:
+    """Drives one channel + (for keyed channels) one params hash.
+
+    Lifecycle:
+      - Created on first subscribe; immediately starts a background task.
+      - Loop body: `cursor()` → if changed, `snapshot()` → broadcast.
+      - On `add(sub)`: if a snapshot is already cached, send it directly to
+        the new subscriber; otherwise the next loop tick will broadcast.
+      - On `remove(sub)`: when the subscription set is empty, cancels its
+        own task and signals the hub to forget it.
+    """
+
+    def __init__(
+        self,
+        *,
+        channel: Channel,
+        params: dict[str, Any] | None,
+        interval: float,
+        on_empty: Callable[[Poller], None],
+    ) -> None:
+        self.channel = channel
+        self.params = params
+        self.interval = interval
+        self._on_empty = on_empty
+
+        self.subs: set[Subscription] = set()
+        self._task: asyncio.Task[None] | None = None
+        self._stopping = False
+        self._wake = asyncio.Event()
+
+        self._last_cursor: Any = _SENTINEL
+        self._last_snapshot: Any = _SENTINEL
+        self._last_error: str | None = None
+
+    @property
+    def has_snapshot(self) -> bool:
+        return self._last_snapshot is not _SENTINEL
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run(), name=f"poller:{self.channel.name}")
+
+    def add(self, sub: Subscription) -> None:
+        self.subs.add(sub)
+        if self.has_snapshot:
+            sub.connection.enqueue(
+                SnapshotMessage(
+                    sub_id=sub.sub_id,
+                    channel=self.channel.name,
+                    data=self._last_snapshot,
+                )
+            )
+
+    def remove(self, sub: Subscription) -> None:
+        self.subs.discard(sub)
+        if not self.subs:
+            self._stopping = True
+            self._wake.set()
+            if self._task is not None:
+                self._task.cancel()
+            self._on_empty(self)
+
+    def _broadcast_snapshot(self) -> None:
+        """Send the cached snapshot as a `snapshot` message to every sub."""
+        for sub in list(self.subs):
+            sub.connection.enqueue(
+                SnapshotMessage(
+                    sub_id=sub.sub_id,
+                    channel=self.channel.name,
+                    data=self._last_snapshot,
+                )
+            )
+
+    def _broadcast_update(self) -> None:
+        for sub in list(self.subs):
+            sub.connection.enqueue(
+                UpdateMessage(
+                    sub_id=sub.sub_id,
+                    channel=self.channel.name,
+                    data=self._last_snapshot,
+                )
+            )
+
+    def _broadcast_error(self, code: str, message: str) -> None:
+        for sub in list(self.subs):
+            sub.connection.enqueue(ErrorMessage(sub_id=sub.sub_id, code=code, message=message))
+
+    async def _run(self) -> None:
+        # First tick happens immediately so the first subscriber doesn't wait
+        # one full interval for their initial snapshot. Subsequent ticks honor
+        # `self.interval`.
+        first = True
+        while not self._stopping:
+            if not first:
+                try:
+                    await asyncio.wait_for(self._wake.wait(), timeout=self.interval)
+                    self._wake.clear()
+                except TimeoutError:
+                    pass
+                if self._stopping:
+                    return
+            first = False
+
+            try:
+                cursor = await self.channel.cursor(self.params)
+            except Exception as e:
+                # Cursor errors are usually transient (DB blip). Log, broadcast
+                # once if subscribers haven't seen this error yet, then keep
+                # ticking.
+                if self._last_error != str(e):
+                    logger.warning("realtime: cursor failed for %s: %s", self.channel.name, e)
+                    self._broadcast_error("cursor_failed", str(e))
+                    self._last_error = str(e)
+                continue
+
+            if cursor is not NoCursor and cursor == self._last_cursor and self.has_snapshot:
+                # No change since last broadcast — skip the heavy query.
+                continue
+
+            try:
+                snapshot = await self.channel.snapshot(self.params)
+            except Exception as e:
+                if self._last_error != str(e):
+                    logger.warning("realtime: snapshot failed for %s: %s", self.channel.name, e)
+                    self._broadcast_error("snapshot_failed", str(e))
+                    self._last_error = str(e)
+                continue
+
+            self._last_error = None
+            had_snapshot = self.has_snapshot
+            self._last_cursor = cursor
+            self._last_snapshot = snapshot
+            if had_snapshot:
+                self._broadcast_update()
+            else:
+                # First snapshot for this poller — broadcast as `snapshot`.
+                self._broadcast_snapshot()
+
+
+_SENTINEL: Any = object()
+
+
+class RealtimeHub:
+    """Central registry: channels in, connections + subscriptions out.
+
+    The hub does not own the WebSocket I/O loop — that's the FastAPI
+    endpoint's job. The hub only manages subscriptions and pollers.
+    """
+
+    def __init__(
+        self,
+        *,
+        default_interval_ms: int = 2000,
+        max_subs_per_conn: int = 64,
+    ) -> None:
+        self.channels: dict[str, Channel] = {}
+        # Per-channel interval overrides, in seconds. Channels not listed use
+        # `default_interval_s`.
+        self._intervals: dict[str, float] = {}
+        self._default_interval_s = default_interval_ms / 1000.0
+        self._max_subs_per_conn = max_subs_per_conn
+
+        self._connections: set[Connection] = set()
+        # (channel_name, params_key_or_None) -> Poller
+        self._pollers: dict[tuple[str, str], Poller] = {}
+
+    def register_channel(self, channel: Channel, *, interval_ms: int | None = None) -> None:
+        if channel.name in self.channels:
+            raise ValueError(f"channel already registered: {channel.name}")
+        self.channels[channel.name] = channel
+        if interval_ms is not None:
+            self._intervals[channel.name] = interval_ms / 1000.0
+
+    # Connection bookkeeping --------------------------------------------------
+
+    def attach(self, conn: Connection) -> None:
+        self._connections.add(conn)
+
+    def detach(self, conn: Connection) -> None:
+        # Drop every subscription on this connection. Iterate over a copy
+        # because `unsubscribe` mutates `conn.subs`.
+        for sub_id in list(conn.subs.keys()):
+            self.unsubscribe(conn, sub_id, ack=False)
+        conn.closed = True
+        self._connections.discard(conn)
+
+    # Subscriptions -----------------------------------------------------------
+
+    def subscribe(
+        self,
+        conn: Connection,
+        sub_id: str,
+        channel_name: str,
+        params: dict[str, Any] | None,
+    ) -> None:
+        if sub_id in conn.subs:
+            conn.enqueue(
+                ErrorMessage(
+                    sub_id=sub_id,
+                    code="already_subscribed",
+                    message=f"sub_id '{sub_id}' is already in use on this connection",
+                )
+            )
+            return
+        if len(conn.subs) >= self._max_subs_per_conn:
+            conn.enqueue(
+                ErrorMessage(
+                    sub_id=sub_id,
+                    code="too_many_subscriptions",
+                    message=f"connection exceeded max_subs={self._max_subs_per_conn}",
+                )
+            )
+            return
+
+        channel = self.channels.get(channel_name)
+        if channel is None:
+            conn.enqueue(
+                ErrorMessage(
+                    sub_id=sub_id,
+                    code="unknown_channel",
+                    message=f"no channel named '{channel_name}'",
+                )
+            )
+            return
+
+        try:
+            normalized_params = channel.validate_params(params)
+        except ValueError as e:
+            conn.enqueue(ErrorMessage(sub_id=sub_id, code="invalid_params", message=str(e)))
+            return
+
+        sub = Subscription(
+            sub_id=sub_id, channel=channel, params=normalized_params, connection=conn
+        )
+        conn.subs[sub_id] = sub
+        # Ack first so clients always see ack-before-snapshot. Then attach to
+        # the poller, which may immediately enqueue a cached snapshot.
+        conn.enqueue(AckMessage(sub_id=sub_id, op="subscribe"))
+        poller = self._get_or_start_poller(channel, normalized_params)
+        sub.poller = poller
+        poller.add(sub)
+
+    def unsubscribe(self, conn: Connection, sub_id: str, *, ack: bool = True) -> None:
+        sub = conn.subs.pop(sub_id, None)
+        if sub is None:
+            if ack:
+                conn.enqueue(
+                    ErrorMessage(sub_id=sub_id, code="not_subscribed", message="no such sub_id")
+                )
+            return
+        if sub.poller is not None:
+            sub.poller.remove(sub)
+        if ack:
+            conn.enqueue(AckMessage(sub_id=sub_id, op="unsubscribe"))
+
+    def update_params(
+        self,
+        conn: Connection,
+        sub_id: str,
+        params: dict[str, Any] | None,
+    ) -> None:
+        sub = conn.subs.get(sub_id)
+        if sub is None:
+            conn.enqueue(
+                ErrorMessage(sub_id=sub_id, code="not_subscribed", message="no such sub_id")
+            )
+            return
+        try:
+            normalized_params = sub.channel.validate_params(params)
+        except ValueError as e:
+            conn.enqueue(ErrorMessage(sub_id=sub_id, code="invalid_params", message=str(e)))
+            return
+        # Detach from current poller, re-attach to (possibly different) poller.
+        old_poller = sub.poller
+        sub.params = normalized_params
+        new_poller = self._get_or_start_poller(sub.channel, normalized_params)
+        if new_poller is old_poller:
+            conn.enqueue(AckMessage(sub_id=sub_id, op="update_params"))
+            return
+        if old_poller is not None:
+            old_poller.remove(sub)
+        sub.poller = new_poller
+        new_poller.add(sub)
+        conn.enqueue(AckMessage(sub_id=sub_id, op="update_params"))
+
+    # Pollers -----------------------------------------------------------------
+
+    def _get_or_start_poller(self, channel: Channel, params: dict[str, Any] | None) -> Poller:
+        if isinstance(channel, KeyedChannel):
+            key = (channel.name, channel.params_key(params))
+        elif isinstance(channel, BroadcastChannel):
+            key = (channel.name, "")
+        else:
+            # Bare Channel — treat as broadcast (one poller).
+            key = (channel.name, "")
+        poller = self._pollers.get(key)
+        if poller is None:
+            interval = self._intervals.get(channel.name, self._default_interval_s)
+            poller = Poller(
+                channel=channel,
+                params=params,
+                interval=interval,
+                on_empty=lambda p, k=key: self._pollers.pop(k, None),
+            )
+            self._pollers[key] = poller
+            poller.start()
+        return poller
+
+    # Test / introspection helpers --------------------------------------------
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._connections)
+
+    @property
+    def poller_count(self) -> int:
+        return len(self._pollers)

--- a/packages/server/dbos_argus/realtime/protocol.py
+++ b/packages/server/dbos_argus/realtime/protocol.py
@@ -1,0 +1,107 @@
+"""Wire protocol for the /ws endpoint.
+
+One socket multiplexes many subscriptions, each tagged by a client-assigned
+`sub_id`. Channel-specific payloads are opaque JSON and live in `data`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# Client → server
+
+
+class SubscribeMessage(BaseModel):
+    type: Literal["subscribe"] = "subscribe"
+    sub_id: str
+    channel: str
+    params: dict[str, Any] | None = None
+
+
+class UnsubscribeMessage(BaseModel):
+    type: Literal["unsubscribe"] = "unsubscribe"
+    sub_id: str
+
+
+class UpdateParamsMessage(BaseModel):
+    """Re-key an existing subscription without re-rendering on the client.
+
+    Server may swap the underlying poller (in `KeyedChannel`) but the
+    `sub_id` is preserved. Client gets a fresh `snapshot` for the new params.
+    """
+
+    type: Literal["update_params"] = "update_params"
+    sub_id: str
+    params: dict[str, Any] | None = None
+
+
+class PingMessage(BaseModel):
+    type: Literal["ping"] = "ping"
+
+
+ClientMessage = SubscribeMessage | UnsubscribeMessage | UpdateParamsMessage | PingMessage
+
+
+# Server → client
+
+
+class SnapshotMessage(BaseModel):
+    """First payload after `subscribe` (or after `update_params`)."""
+
+    type: Literal["snapshot"] = "snapshot"
+    sub_id: str
+    channel: str
+    data: Any
+
+
+class UpdateMessage(BaseModel):
+    """Subsequent payload — sent only when the channel cursor advanced."""
+
+    type: Literal["update"] = "update"
+    sub_id: str
+    channel: str
+    data: Any
+
+
+class ErrorMessage(BaseModel):
+    type: Literal["error"] = "error"
+    sub_id: str | None = None
+    code: str
+    message: str
+
+
+class PongMessage(BaseModel):
+    type: Literal["pong"] = "pong"
+
+
+class AckMessage(BaseModel):
+    """Confirms that a non-data control message landed (subscribe / unsubscribe).
+
+    Useful for tests and for clients that want to know when an unsubscribe
+    has been honored on the server.
+    """
+
+    type: Literal["ack"] = "ack"
+    sub_id: str
+    op: Literal["subscribe", "unsubscribe", "update_params"]
+
+
+ServerMessage = SnapshotMessage | UpdateMessage | ErrorMessage | PongMessage | AckMessage
+
+
+# Convenience top-level discriminated unions for parsing.
+
+
+class IncomingEnvelope(BaseModel):
+    """Discriminator-only model for parsing arbitrary client messages.
+
+    Pydantic doesn't dispatch a tagged union from a top-level `BaseModel`
+    parse call without a wrapper. We use this purely to validate the
+    `type` discriminator before routing — actual payload parsing happens
+    against the concrete model in the union.
+    """
+
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/packages/server/dbos_argus/settings.py
+++ b/packages/server/dbos_argus/settings.py
@@ -24,6 +24,21 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:5173"
     log_level: str = "INFO"
 
+    # Realtime (WebSocket) layer. The /ws endpoint runs server-side polling
+    # tasks and broadcasts deltas to subscribed clients. Disable to fall back
+    # to client-side REST polling.
+    realtime_enabled: bool = True
+    # Default tick interval for data channels (workflows, stats, schedules,
+    # notifications). Health uses its own slower interval. Pollers gate the
+    # heavy query behind a cheap "did anything change?" cursor query, so this
+    # is roughly the upper bound on update latency, not query rate.
+    realtime_interval_ms: int = 2000
+    realtime_health_interval_ms: int = 5000
+    # Cap subscriptions per client connection. A misbehaving (or compromised)
+    # client otherwise could open one socket and spin up unlimited keyed
+    # pollers by sending distinct param hashes.
+    realtime_max_subs_per_conn: int = 64
+
     @field_validator("database_url")
     @classmethod
     def _force_async_driver(cls, v: str) -> str:

--- a/packages/server/tests/test_realtime_endpoint.py
+++ b/packages/server/tests/test_realtime_endpoint.py
@@ -1,0 +1,143 @@
+"""End-to-end WebSocket tests using FastAPI's TestClient.
+
+Validates the wire protocol: ack-then-snapshot ordering, ping/pong, error
+shapes, multiplexed sub_ids on a single socket. Uses fake channels swapped
+into a fresh app — avoids depending on the real DB, which we don't want
+test-runs to require.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dbos_argus.realtime import RealtimeHub, register_websocket_route
+from dbos_argus.realtime.channel import BroadcastChannel, KeyedChannel
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _Static(BroadcastChannel):
+    name = "static"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return "v1"
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        return {"value": "static"}
+
+
+class _Echo(KeyedChannel):
+    name = "echo"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return ("v", self.params_key(params))
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        return {"params": params or {}}
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(_Static())
+    hub.register_channel(_Echo())
+    # Allow any origin for tests (TestClient doesn't send Origin).
+    register_websocket_route(app, hub, allowed_origins=[])
+    return app
+
+
+def _drain_until(ws, predicate, *, max_msgs: int = 8) -> list[dict[str, Any]]:
+    """Read messages until `predicate(msg)` returns True or we hit max_msgs.
+
+    Returns every message read, including the one that satisfied the
+    predicate. Raises RuntimeError on overflow.
+    """
+    out: list[dict[str, Any]] = []
+    for _ in range(max_msgs):
+        msg = ws.receive_json()
+        out.append(msg)
+        if predicate(msg):
+            return out
+    raise RuntimeError(f"predicate not satisfied within {max_msgs} messages: {out}")
+
+
+def test_subscribe_emits_ack_then_snapshot() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json({"type": "subscribe", "sub_id": "s1", "channel": "static"})
+        msgs = _drain_until(ws, lambda m: m["type"] == "snapshot")
+        assert msgs[0] == {"type": "ack", "sub_id": "s1", "op": "subscribe"}
+        snap = msgs[-1]
+        assert snap["sub_id"] == "s1"
+        assert snap["channel"] == "static"
+        assert snap["data"] == {"value": "static"}
+
+
+def test_ping_pong() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json({"type": "ping"})
+        msg = ws.receive_json()
+        assert msg == {"type": "pong"}
+
+
+def test_unknown_channel_returns_error() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json({"type": "subscribe", "sub_id": "s1", "channel": "nope"})
+        msg = ws.receive_json()
+        assert msg["type"] == "error"
+        assert msg["sub_id"] == "s1"
+        assert msg["code"] == "unknown_channel"
+
+
+def test_unsubscribe_acks_and_silences_channel() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json({"type": "subscribe", "sub_id": "s1", "channel": "static"})
+        _drain_until(ws, lambda m: m["type"] == "snapshot")
+
+        ws.send_json({"type": "unsubscribe", "sub_id": "s1"})
+        ack = ws.receive_json()
+        assert ack == {"type": "ack", "sub_id": "s1", "op": "unsubscribe"}
+
+
+def test_multiple_subscriptions_share_one_socket() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json({"type": "subscribe", "sub_id": "a", "channel": "echo", "params": {"id": "x"}})
+        ws.send_json({"type": "subscribe", "sub_id": "b", "channel": "echo", "params": {"id": "y"}})
+
+        # Each sub gets its own ack + snapshot. The hub doesn't guarantee
+        # ordering across subs, but every message tags its sub_id, so we
+        # can sort them out by that.
+        seen_acks: set[str] = set()
+        seen_snaps: dict[str, dict[str, Any]] = {}
+        for _ in range(4):
+            msg = ws.receive_json()
+            if msg["type"] == "ack":
+                seen_acks.add(msg["sub_id"])
+            elif msg["type"] == "snapshot":
+                seen_snaps[msg["sub_id"]] = msg["data"]
+        assert seen_acks == {"a", "b"}
+        assert seen_snaps["a"] == {"params": {"id": "x"}}
+        assert seen_snaps["b"] == {"params": {"id": "y"}}
+
+
+def test_update_params_emits_fresh_snapshot() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json(
+            {"type": "subscribe", "sub_id": "s1", "channel": "echo", "params": {"id": "x"}}
+        )
+        _drain_until(ws, lambda m: m["type"] == "snapshot")
+
+        ws.send_json({"type": "update_params", "sub_id": "s1", "params": {"id": "y"}})
+        msgs = _drain_until(ws, lambda m: m["type"] == "snapshot")
+        # ack + snapshot for the new params.
+        types = [m["type"] for m in msgs]
+        assert "ack" in types
+        snap = msgs[-1]
+        assert snap["data"] == {"params": {"id": "y"}}
+
+
+def test_bad_message_returns_error() -> None:
+    with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
+        ws.send_json({"type": "frobnicate"})
+        msg = ws.receive_json()
+        assert msg["type"] == "error"
+        assert msg["code"] == "unknown_type"

--- a/packages/server/tests/test_realtime_hub.py
+++ b/packages/server/tests/test_realtime_hub.py
@@ -63,6 +63,22 @@ class StaticChannel(BroadcastChannel):
         return {"value": "static"}
 
 
+class NoCursorStableChannel(BroadcastChannel):
+    """No cursor (the default) but a stable snapshot. Models the
+    `workflow` / `health` channels: every tick re-snapshots, but the
+    payload is often byte-identical between ticks.
+    """
+
+    name = "no-cursor-stable"
+
+    def __init__(self) -> None:
+        self.snapshot_calls = 0
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        self.snapshot_calls += 1
+        return {"value": "stable"}
+
+
 class ParamEchoChannel(KeyedChannel):
     """Snapshot echoes the params back. Cursor changes any time params do, so
     distinct params hashes get distinct pollers (which is what we want to
@@ -244,6 +260,30 @@ async def test_static_cursor_skips_subsequent_broadcasts() -> None:
     types = [m.type for m in msgs]  # type: ignore[attr-defined]
     assert types.count("snapshot") == 1
     assert types.count("update") == 0
+
+    hub.detach(conn)
+
+
+async def test_identical_snapshot_suppresses_update() -> None:
+    """No-cursor channels re-run snapshot every tick. If the payload is
+    identical, the hub should not emit `update` messages — clients don't
+    need to re-render unchanged data.
+    """
+    hub = RealtimeHub(default_interval_ms=20)
+    channel = NoCursorStableChannel()
+    hub.register_channel(channel)
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "no-cursor-stable", None)
+    await asyncio.sleep(0.15)  # multiple ticks elapse
+
+    msgs = _drain(conn)
+    types = [m.type for m in msgs]  # type: ignore[attr-defined]
+    assert types.count("snapshot") == 1
+    assert types.count("update") == 0
+    # Snapshot still ran on every tick (the dedupe is post-snapshot).
+    assert channel.snapshot_calls >= 2
 
     hub.detach(conn)
 

--- a/packages/server/tests/test_realtime_hub.py
+++ b/packages/server/tests/test_realtime_hub.py
@@ -1,0 +1,309 @@
+"""Hub / poller unit tests using fake in-memory channels (no DB)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from dbos_argus.realtime.channel import BroadcastChannel, KeyedChannel
+from dbos_argus.realtime.hub import Connection, RealtimeHub
+from dbos_argus.realtime.protocol import (
+    AckMessage,
+    ServerMessage,
+    SnapshotMessage,
+    UpdateMessage,
+)
+
+
+class _FakeWebSocket:
+    """Stand-in for the FastAPI WebSocket so the hub can hand out Connections
+    in tests without an actual socket. Only the attributes the hub touches
+    matter — `headers`, `accept`, `send_json` aren't reached because the
+    writer task isn't started in these tests."""
+
+
+def _make_conn() -> Connection:
+    return Connection(websocket=_FakeWebSocket())  # type: ignore[arg-type]
+
+
+def _drain(conn: Connection) -> list[ServerMessage]:
+    msgs: list[ServerMessage] = []
+    while not conn.out_queue.empty():
+        msgs.append(conn.out_queue.get_nowait())
+    return msgs
+
+
+class CounterChannel(BroadcastChannel):
+    """Snapshot returns an incrementing tick; cursor matches snapshot so each
+    poll is treated as a change. Used to verify push semantics deterministically.
+    """
+
+    name = "counter"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return self.calls
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        self.calls += 1
+        return {"tick": self.calls}
+
+
+class StaticChannel(BroadcastChannel):
+    """Cursor never changes — useful for testing the de-dupe path."""
+
+    name = "static"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        return "v1"
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        return {"value": "static"}
+
+
+class ParamEchoChannel(KeyedChannel):
+    """Snapshot echoes the params back. Cursor changes any time params do, so
+    distinct params hashes get distinct pollers (which is what we want to
+    verify), and any single poller's snapshot is stable."""
+
+    name = "echo"
+
+    async def cursor(self, params: dict[str, Any] | None) -> Any:
+        # Stable per-params; the hub doesn't share pollers across keys, so
+        # this poller's cursor never changes once initialized.
+        return ("v", self.params_key(params))
+
+    async def snapshot(self, params: dict[str, Any] | None) -> Any:
+        return {"params": params or {}}
+
+
+# --- Subscribe / unsubscribe ------------------------------------------------
+
+
+async def test_subscribe_yields_ack_then_snapshot() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(CounterChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "counter", None)
+
+    # The poller's first tick runs as soon as the event loop yields — it
+    # has no initial sleep. Give it a chance to land.
+    await asyncio.sleep(0.05)
+
+    msgs = _drain(conn)
+    assert len(msgs) == 2
+    assert isinstance(msgs[0], AckMessage)
+    assert msgs[0].sub_id == "s1"
+    assert msgs[0].op == "subscribe"
+    assert isinstance(msgs[1], SnapshotMessage)
+    assert msgs[1].sub_id == "s1"
+    assert msgs[1].channel == "counter"
+    assert msgs[1].data == {"tick": 1}
+
+    hub.detach(conn)
+
+
+async def test_unknown_channel_emits_error() -> None:
+    hub = RealtimeHub()
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "nope", None)
+
+    msgs = _drain(conn)
+    assert len(msgs) == 1
+    assert msgs[0].type == "error"  # type: ignore[attr-defined]
+    assert "nope" in msgs[0].message  # type: ignore[attr-defined]
+
+    hub.detach(conn)
+
+
+async def test_unsubscribe_drops_poller_on_last_subscriber() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(StaticChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "static", None)
+    await asyncio.sleep(0.01)
+    assert hub.poller_count == 1
+
+    hub.unsubscribe(conn, "s1")
+    # Poller is removed synchronously from the hub bookkeeping.
+    assert hub.poller_count == 0
+
+    hub.detach(conn)
+
+
+async def test_broadcast_channel_shares_one_poller() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(StaticChannel())
+    conn1 = _make_conn()
+    conn2 = _make_conn()
+    hub.attach(conn1)
+    hub.attach(conn2)
+
+    hub.subscribe(conn1, "a", "static", None)
+    hub.subscribe(conn2, "b", "static", None)
+    assert hub.poller_count == 1
+
+    # Both connections receive a snapshot.
+    await asyncio.sleep(0.05)
+    msgs1 = [m for m in _drain(conn1) if isinstance(m, SnapshotMessage)]
+    msgs2 = [m for m in _drain(conn2) if isinstance(m, SnapshotMessage)]
+    assert len(msgs1) == 1 and len(msgs2) == 1
+    assert msgs1[0].data == {"value": "static"} == msgs2[0].data
+
+    hub.detach(conn1)
+    hub.detach(conn2)
+
+
+async def test_keyed_channel_separates_pollers_by_params() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(ParamEchoChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "echo", {"id": "a"})
+    hub.subscribe(conn, "s2", "echo", {"id": "b"})
+    hub.subscribe(conn, "s3", "echo", {"id": "a"})  # shares with s1
+
+    assert hub.poller_count == 2
+
+    hub.detach(conn)
+
+
+# --- update_params ----------------------------------------------------------
+
+
+async def test_update_params_moves_subscription_to_new_poller() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(ParamEchoChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "echo", {"id": "a"})
+    await asyncio.sleep(0.05)
+    _drain(conn)  # discard ack + initial snapshot
+
+    hub.update_params(conn, "s1", {"id": "b"})
+    await asyncio.sleep(0.05)
+
+    msgs = _drain(conn)
+    # Expect an ack and a fresh snapshot for the new params.
+    types = [m.type for m in msgs]  # type: ignore[attr-defined]
+    assert "ack" in types
+    snapshots = [m for m in msgs if isinstance(m, SnapshotMessage)]
+    assert any(m.data == {"params": {"id": "b"}} for m in snapshots)
+
+    # Old poller should be gone, new one in its place.
+    assert hub.poller_count == 1
+
+    hub.detach(conn)
+
+
+async def test_update_params_same_key_is_noop_for_pollers() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(ParamEchoChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "echo", {"id": "a"})
+    await asyncio.sleep(0.05)
+    _drain(conn)
+
+    hub.update_params(conn, "s1", {"id": "a"})
+    msgs = _drain(conn)
+    # Just an ack, no extra snapshot, and the existing poller stays.
+    assert [m.type for m in msgs] == ["ack"]  # type: ignore[attr-defined]
+    assert hub.poller_count == 1
+
+    hub.detach(conn)
+
+
+# --- Cursor de-dupe and updates ---------------------------------------------
+
+
+async def test_static_cursor_skips_subsequent_broadcasts() -> None:
+    """If the cursor doesn't change, no `update` messages should follow the
+    initial `snapshot`."""
+    hub = RealtimeHub(default_interval_ms=20)  # short tick to exercise loop
+    hub.register_channel(StaticChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "static", None)
+    await asyncio.sleep(0.15)  # several ticks have elapsed
+
+    msgs = _drain(conn)
+    # Exactly one ack + one snapshot, no updates.
+    types = [m.type for m in msgs]  # type: ignore[attr-defined]
+    assert types.count("snapshot") == 1
+    assert types.count("update") == 0
+
+    hub.detach(conn)
+
+
+async def test_changing_cursor_emits_updates() -> None:
+    hub = RealtimeHub(default_interval_ms=20)
+    hub.register_channel(CounterChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "s1", "counter", None)
+    await asyncio.sleep(0.12)  # several ticks
+
+    msgs = _drain(conn)
+    snapshots = [m for m in msgs if isinstance(m, SnapshotMessage)]
+    updates = [m for m in msgs if isinstance(m, UpdateMessage)]
+    assert len(snapshots) == 1
+    assert len(updates) >= 1
+    # Ticks are strictly increasing.
+    seen = [snapshots[0].data["tick"], *(u.data["tick"] for u in updates)]
+    assert seen == sorted(seen)
+    assert seen[0] < seen[-1]
+
+    hub.detach(conn)
+
+
+# --- Connection bookkeeping -------------------------------------------------
+
+
+async def test_detach_unsubscribes_all_and_cleans_pollers() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000)
+    hub.register_channel(StaticChannel())
+    hub.register_channel(ParamEchoChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "a", "static", None)
+    hub.subscribe(conn, "b", "echo", {"id": "x"})
+    hub.subscribe(conn, "c", "echo", {"id": "y"})
+    assert hub.poller_count == 3
+
+    hub.detach(conn)
+    assert hub.poller_count == 0
+    assert hub.connection_count == 0
+
+
+async def test_max_subs_per_connection_enforced() -> None:
+    hub = RealtimeHub(default_interval_ms=10_000, max_subs_per_conn=2)
+    hub.register_channel(ParamEchoChannel())
+    conn = _make_conn()
+    hub.attach(conn)
+
+    hub.subscribe(conn, "a", "echo", {"id": "1"})
+    hub.subscribe(conn, "b", "echo", {"id": "2"})
+    hub.subscribe(conn, "c", "echo", {"id": "3"})  # over the limit
+
+    msgs = _drain(conn)
+    types = [m.type for m in msgs]  # type: ignore[attr-defined]
+    assert types.count("error") == 1
+    error = next(m for m in msgs if m.type == "error")  # type: ignore[attr-defined]
+    assert error.code == "too_many_subscriptions"  # type: ignore[attr-defined]
+
+    hub.detach(conn)

--- a/packages/server/tests/test_realtime_workflow_channels.py
+++ b/packages/server/tests/test_realtime_workflow_channels.py
@@ -1,0 +1,112 @@
+"""Param normalization tests for the workflows + workflow channels.
+
+These don't hit the DB — they only validate the input-coercion layer
+so the channel rejects bad client input before it reaches SQL.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dbos_argus.realtime.channels.workflow import WorkflowChannel
+from dbos_argus.realtime.channels.workflows import WorkflowsChannel
+
+# --- WorkflowsChannel.validate_params ---------------------------------------
+
+
+def test_workflows_defaults_when_params_omitted() -> None:
+    ch = WorkflowsChannel()
+    out = ch.validate_params(None)
+    assert out == {
+        "limit": 50,
+        "q": None,
+        "started_after_ms": None,
+        "started_before_ms": None,
+        "statuses": None,
+        "queue_name": None,
+        "grouped": True,
+        "hide_scheduled": False,
+    }
+
+
+def test_workflows_normalizes_iso_datetime_to_epoch_ms() -> None:
+    ch = WorkflowsChannel()
+    out = ch.validate_params(
+        {"started_after": "2026-05-01T00:00:00+00:00", "started_before": 1_780_000_000_000}
+    )
+    assert out["started_after_ms"] == 1_777_593_600_000  # type: ignore[index]
+    assert out["started_before_ms"] == 1_780_000_000_000  # type: ignore[index]
+
+
+def test_workflows_strips_blank_q() -> None:
+    ch = WorkflowsChannel()
+    out = ch.validate_params({"q": "   "})
+    assert out["q"] is None  # type: ignore[index]
+
+
+def test_workflows_rejects_unknown_keys() -> None:
+    ch = WorkflowsChannel()
+    with pytest.raises(ValueError, match="unknown params"):
+        ch.validate_params({"weird": True})
+
+
+def test_workflows_rejects_bad_limit() -> None:
+    ch = WorkflowsChannel()
+    with pytest.raises(ValueError, match="limit"):
+        ch.validate_params({"limit": 0})
+    with pytest.raises(ValueError, match="limit"):
+        ch.validate_params({"limit": 9999})
+
+
+def test_workflows_rejects_non_list_status() -> None:
+    ch = WorkflowsChannel()
+    with pytest.raises(ValueError, match="status"):
+        ch.validate_params({"status": "PENDING"})
+
+
+def test_workflows_empty_status_list_becomes_none() -> None:
+    """An empty list filter is semantically the same as no filter; the
+    snapshot should treat both identically so the params_key dedupes them
+    onto one poller."""
+    ch = WorkflowsChannel()
+    a = ch.validate_params({"status": []})
+    b = ch.validate_params(None)
+    assert a == b
+
+
+def test_workflows_params_key_stable_across_key_order() -> None:
+    """`grouped: true` then `limit: 10` should hash the same as the
+    reverse — ensures clients don't accidentally double up pollers by
+    reordering keys."""
+    ch = WorkflowsChannel()
+    a = ch.validate_params({"grouped": True, "limit": 10})
+    b = ch.validate_params({"limit": 10, "grouped": True})
+    assert ch.params_key(a) == ch.params_key(b)
+
+
+# --- WorkflowChannel.validate_params ---------------------------------------
+
+
+def test_workflow_requires_id() -> None:
+    ch = WorkflowChannel()
+    with pytest.raises(ValueError, match="id"):
+        ch.validate_params(None)
+    with pytest.raises(ValueError, match="id"):
+        ch.validate_params({})
+    with pytest.raises(ValueError, match="id"):
+        ch.validate_params({"id": ""})
+    with pytest.raises(ValueError, match="id"):
+        ch.validate_params({"id": "   "})
+
+
+def test_workflow_keeps_only_id() -> None:
+    ch = WorkflowChannel()
+    out = ch.validate_params({"id": "abc-123", "ignored": "yes"})
+    # The channel discards extra keys so the params_key is stable.
+    assert out == {"id": "abc-123"}
+
+
+def test_workflow_distinct_ids_make_distinct_keys() -> None:
+    ch = WorkflowChannel()
+    a = ch.validate_params({"id": "a"})
+    b = ch.validate_params({"id": "b"})
+    assert ch.params_key(a) != ch.params_key(b)

--- a/tests/sample-app/heartbeat_runner.py
+++ b/tests/sample-app/heartbeat_runner.py
@@ -18,6 +18,7 @@ Run:
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import time
 
@@ -52,10 +53,18 @@ def main() -> None:
         scheduled.HEARTBEAT_QUEUE_NAME,
     )
 
-    stop = {"now": False}
+    stop = {"now": False, "count": 0}
 
+    # Second SIGINT escalates to a hard exit — DBOS.destroy() waits for any
+    # in-flight workflows to drain (notably DBOS.sleep, which is not
+    # interruptible) and can otherwise hold the process indefinitely.
     def _on_signal(_signum, _frame):
+        stop["count"] += 1
+        if stop["count"] >= 2:
+            LOG.warning("force exit (second ctrl-C)")
+            os._exit(130)
         stop["now"] = True
+        LOG.info("shutdown requested — ctrl-C again to force exit")
 
     signal.signal(signal.SIGINT, _on_signal)
     signal.signal(signal.SIGTERM, _on_signal)

--- a/tests/sample-app/runner.py
+++ b/tests/sample-app/runner.py
@@ -17,6 +17,7 @@ Run:
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import time
 import uuid
@@ -114,10 +115,20 @@ def idle() -> None:
 
 def _idle() -> None:
     LOG.info("idle — workflows owned by executor_id=%s; ctrl-C to exit", EXECUTOR_ID)
-    stop = {"now": False}
+    stop = {"now": False, "count": 0}
 
+    # First SIGINT requests graceful shutdown. `DBOS.destroy()` waits for
+    # in-flight workflow threads to drain — a workflow mid-`DBOS.sleep(N)`
+    # holds the process for up to N seconds because DBOS.sleep is not
+    # interruptible. A second SIGINT escalates to a hard exit so the user
+    # is never stuck staring at "shutting down".
     def _on_signal(_signum, _frame):
+        stop["count"] += 1
+        if stop["count"] >= 2:
+            LOG.warning("force exit (second ctrl-C)")
+            os._exit(130)
         stop["now"] = True
+        LOG.info("shutdown requested — ctrl-C again to force exit")
 
     signal.signal(signal.SIGINT, _on_signal)
     signal.signal(signal.SIGTERM, _on_signal)

--- a/tests/sample-app/runner.py
+++ b/tests/sample-app/runner.py
@@ -56,8 +56,13 @@ def seed() -> None:
     DBOS.launch()
     LOG.info("argus-runner up — executor_id=%s", EXECUTOR_ID)
 
-    LOG.info("process_order result: %s", process_order("ord-1001"))
-    LOG.info("send_campaign result: %s", send_campaign("spring-sale", 20))
+    # Fire-and-forget so all three trees run concurrently — with the random
+    # 3-10s step pauses, awaiting `process_order` / `send_campaign` here would
+    # delay `fulfill_order`'s start by minutes.
+    process_handle = DBOS.start_workflow(process_order, "ord-1001")
+    campaign_handle = DBOS.start_workflow(send_campaign, "spring-sale", 20)
+    LOG.info("started process_order: %s", process_handle.workflow_id)
+    LOG.info("started send_campaign: %s", campaign_handle.workflow_id)
 
     fulfill_workflow_id = f"fulfill-{uuid.uuid4().hex[:8]}"
     with SetWorkflowID(fulfill_workflow_id):

--- a/tests/sample-app/scheduler.py
+++ b/tests/sample-app/scheduler.py
@@ -18,6 +18,7 @@ stop; start it again and they resume.
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import time
 
@@ -52,10 +53,18 @@ def main() -> None:
         scheduled.HEARTBEAT_SCHEDULE,
     )
 
-    stop = {"now": False}
+    stop = {"now": False, "count": 0}
 
+    # Second SIGINT escalates to a hard exit — DBOS.destroy() waits for any
+    # in-flight workflows to drain (notably DBOS.sleep, which is not
+    # interruptible) and can otherwise hold the process indefinitely.
     def _on_signal(_signum, _frame):
+        stop["count"] += 1
+        if stop["count"] >= 2:
+            LOG.warning("force exit (second ctrl-C)")
+            os._exit(130)
         stop["now"] = True
+        LOG.info("shutdown requested — ctrl-C again to force exit")
 
     signal.signal(signal.SIGINT, _on_signal)
     signal.signal(signal.SIGTERM, _on_signal)

--- a/tests/sample-app/workflows.py
+++ b/tests/sample-app/workflows.py
@@ -176,9 +176,9 @@ def reconcile_inventory(order_id: str) -> dict:
         # Demo of the cancellation feature: ops cancels `stock_check` and
         # the parent observes it here. Swallow so reconcile keeps going.
         LOG.warning("stock_check was cancelled: %s", e)
-    # 7d sleep keeps this workflow PENDING in the dashboard. `fulfill_order`
-    # never awaits it, so the parent can move on.
-    DBOS.sleep(86400 * 7)
+    # 2m sleep keeps this workflow PENDING long enough to be visible in the
+    # dashboard. `fulfill_order` never awaits it, so the parent can move on.
+    DBOS.sleep(120)
     return {"kind": "reconcile", "order_id": order_id, "completed": True}
 
 

--- a/tests/sample-app/workflows.py
+++ b/tests/sample-app/workflows.py
@@ -10,6 +10,7 @@ operations and don't need workflow definitions).
 from __future__ import annotations
 
 import logging
+import random
 import time
 
 from dbos import DBOS, SetWorkflowID
@@ -21,15 +22,21 @@ CARRIER_CONFIRMATION_TOPIC = "carrier-confirmation"
 OPS_SIGNOFF_TOPIC = "ops-signoff"
 
 
+# Steps reachable from `fulfill_order`'s tree sleep a random 3-10s so the
+# workflow takes long enough to watch progress live in the dashboard.
+def _fulfill_pause() -> None:
+    time.sleep(random.uniform(3, 10))
+
+
 @DBOS.step()
 def validate_order(order_id: str) -> dict:
-    time.sleep(0.08)
+    _fulfill_pause()
     return {"order_id": order_id, "valid": True, "items_count": 3}
 
 
 @DBOS.step()
 def compute_total(item_count: int, region: str) -> dict:
-    time.sleep(0.04)
+    _fulfill_pause()
     rate = {"us": 1.0, "eu": 0.85, "uk": 0.78}.get(region, 1.0)
     subtotal = item_count * 19.99
     return {
@@ -42,19 +49,19 @@ def compute_total(item_count: int, region: str) -> dict:
 
 @DBOS.step()
 def log_event(event: str) -> None:
-    time.sleep(0.02)
+    _fulfill_pause()
     LOG.info("event: %s", event)
 
 
 @DBOS.step()
 def audit(action: str) -> dict:
-    time.sleep(0.01)
+    _fulfill_pause()
     return {"action": action, "actor": "fulfillment"}
 
 
 @DBOS.step()
 def package_items(order_id: str) -> str:
-    time.sleep(0.01)
+    _fulfill_pause()
     return f"PKG-{order_id.upper()}"
 
 
@@ -66,7 +73,7 @@ def count_items(label: str) -> int:
 
 @DBOS.step()
 def run_fraud_scan(order_id: str) -> None:
-    time.sleep(0.02)
+    _fulfill_pause()
     raise ValueError(f"suspicious activity detected for order {order_id!r}")
 
 

--- a/tests/sample-app/workflows.py
+++ b/tests/sample-app/workflows.py
@@ -160,10 +160,10 @@ def prepare_shipment(
 def stock_check(order_id: str) -> dict:
     audit(f"stock-check-start:{order_id}")
     validate_order(order_id)
-    # Long sleep so `argus-ops cancel-stock` can hit it mid-flight.
+    # Sleep long enough for `argus-ops cancel-stock` to hit it mid-flight.
     # `DBOS.sleep` is NOT interruptible — the thread blocks for the full
     # duration before observing the CANCELLED status.
-    DBOS.sleep(120)
+    DBOS.sleep(30)
     log_event(f"stock-verified:{order_id}")
     return {"kind": "stock", "order_id": order_id, "in_stock": True}
 
@@ -183,9 +183,9 @@ def reconcile_inventory(order_id: str) -> dict:
         # Demo of the cancellation feature: ops cancels `stock_check` and
         # the parent observes it here. Swallow so reconcile keeps going.
         LOG.warning("stock_check was cancelled: %s", e)
-    # 2m sleep keeps this workflow PENDING long enough to be visible in the
+    # 30s sleep keeps this workflow PENDING long enough to be visible in the
     # dashboard. `fulfill_order` never awaits it, so the parent can move on.
-    DBOS.sleep(120)
+    DBOS.sleep(30)
     return {"kind": "reconcile", "order_id": order_id, "completed": True}
 
 
@@ -204,12 +204,13 @@ def fulfill_order(order_id: str) -> dict:
     log_event(f"shipment-dispatched:{order_id}")
     fraud = DBOS.start_workflow(fraud_check, order_id)
     pricing = compute_total(validation["items_count"], "us")
-    # Fire-and-forget: sleeps for 7 days so the workflow stays PENDING in the
-    # dashboard alongside the completed siblings. Id pinned so ops can locate
-    # its `stock_check` grandchild to cancel.
+    # Fire-and-forget initially so it runs concurrently. Awaited at the very
+    # end (after the ops-signoff recv + a 30s sleep) so the dashboard shows
+    # the parent waiting on this child. Id pinned so ops can locate its
+    # `stock_check` grandchild to cancel.
     reconcile_workflow_id = f"{DBOS.workflow_id}-reconcile"
     with SetWorkflowID(reconcile_workflow_id):
-        DBOS.start_workflow(reconcile_inventory, order_id)
+        reconcile = DBOS.start_workflow(reconcile_inventory, order_id)
     label = package_items(order_id)
     nested_branch.get_result()
     # Swallow the fraud check's failure so the parent itself still succeeds —
@@ -223,6 +224,8 @@ def fulfill_order(order_id: str) -> dict:
     # Block waiting for an "ops-signoff" notification — `argus-ops ops-signoff`
     # unblocks it. Until then, `fulfill_order` stays PENDING in the dashboard.
     DBOS.recv(topic=OPS_SIGNOFF_TOPIC, timeout_seconds=86400)
+    DBOS.sleep(30)
+    reconcile.get_result()
     return {
         "kind": "fulfillment",
         "order_id": order_id,

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "passThroughEnv": ["ARGUS_DATABASE_URL", "ARGUS_*"]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
## Summary

- **Realtime WebSocket layer** at `/ws`. Multiplexed `subscribe` / `unsubscribe` / `update_params` / `ping` protocol. Seven channels (`health`, `stats`, `workflows`, `workflow`, `schedules`, `notifications`, `timeseries`) all backed by the same `fetch_*` helpers their REST counterparts use, going through `ArgusDB` so SQLite + Postgres stay in lockstep.
- **Cursor-gated polling** with post-snapshot dedupe — cursor-less channels (`workflow`, `health`) suppress `update` broadcasts when the payload is byte-identical to the cached one, which keeps xyflow edge-dash animations from restarting on every tick.
- **Console rewired onto the WS client.** All `+page.svelte` routes now subscribe through `realtimeClient` instead of polling REST. Connection indicator re-polls `/api/sql-diagnostics` on a 5s cadence while issues are reported, so the schema state recovers without a hard refresh after a DBOS app first connects.
- **`pnpm run dev:sqlite`** and Turbo `passThroughEnv` for `ARGUS_*` so the dev stack can target SQLite without editing files.
- **Sample-app polish.** Step impls reachable from `fulfill_order`'s tree sleep a random 3–10s so the dashboard is watchable live; `runner seed` fires `process_order` / `send_campaign` / `fulfill_order` concurrently; second ctrl-C force-exits the runners (DBOS.sleep is non-interruptible). `stock_check` and `reconcile_inventory`'s trailing sleeps drop to 30s; `fulfill_order` now awaits `reconcile_inventory` after the ops-signoff recv.
- **Workflow flow fix.** ELK collapses an empty container to ~0×0; floor laid-out container dimensions so a freshly-spawned workflow renders its header (name + ID) from the start.

## Test plan

- [x] `pnpm run lint` (ruff + svelte-check + tsc)
- [x] `pnpm run test` (pytest + vitest, including new `test_realtime_hub.py` and `test_realtime_workflow_channels.py`)
- [x] `pnpm run build`
- [x] Manual end-to-end via Chrome automation: `argus-ops` send / cancel / signoff actions reflect live in the UI within one tick
- [x] Verified `pnpm run dev` (Postgres) and `pnpm run dev:sqlite` (SQLite) both serve the console + WS endpoint