### PR TITLE
Adopt workflow_status.completed_at (DBOS 2.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Tested against DBOS 2.23.0** — see `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility; the dependency floor is now `dbos>=2.23.0`. Pointing Argus at an older DBOS database whose `dbos.workflow_status` lacks `completed_at` will error on the workflow list / detail reads.
+
+### Added
+- Workflow **completion time**. DBOS 2.23.0 added `dbos.workflow_status.completed_at`,
+  the canonical wall-clock timestamp for when a workflow reached a terminal
+  state. Argus now reads it: it appears as `completed_at` on the workflow
+  list and detail API/realtime payloads, and the workflow detail pane shows
+  a **Completed** row and computes the workflow **Duration** from
+  `started_at → completed_at` (falling back to `updated_at` while still
+  running). Null for workflows that haven't finished.
+
+### Changed
+- Schema snapshot regenerated against DBOS 2.23.0 (closes the `dbos-watch`
+  drift issue). `workflow_status.completed_at` is now argus-tracked.
+- Bumped the `dbos` dependency floor to `>=2.23.0` to align Argus with the
+  DBOS release that introduced `completed_at`.
+
 ## [0.0.27] - 2026-05-09
 
 > **Tested against DBOS 2.21.0** — see `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Other DBOS versions may still work; the in-app connection indicator surfaces any schema mismatches.

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -77,8 +77,10 @@
     if (!selection) return null;
     if (selection.kind === "workflow") {
       const w = selection.workflow;
-      const dur =
-        new Date(w.updated_at).getTime() - new Date(w.started_at).getTime();
+      // For terminal workflows DBOS stamps `completed_at` (2.23.0+); it's the
+      // precise finish time. Fall back to `updated_at` while still running.
+      const end = w.completed_at ?? w.updated_at;
+      const dur = new Date(end).getTime() - new Date(w.started_at).getTime();
       return {
         resultLabel: "Workflow details",
         title: w.name ?? "—",
@@ -123,6 +125,12 @@
       items.push({ label: "Duration", value: formatDuration(heading.durationMs) });
     if (selection.kind === "workflow") {
       const w = selection.workflow;
+      if (w.completed_at)
+        items.push({
+          label: "Completed",
+          value: new Date(w.completed_at).toLocaleString(),
+          title: w.completed_at,
+        });
       if (w.queue_name) items.push({ label: "Queue", value: w.queue_name });
       if (w.executor_id)
         items.push({ label: "Executor", value: w.executor_id, title: w.executor_id });

--- a/apps/console/src/lib/workflow-tree.ts
+++ b/apps/console/src/lib/workflow-tree.ts
@@ -10,6 +10,9 @@ export type Workflow = {
   priority: number;
   started_at: string;
   updated_at: string;
+  // Wall-clock completion (workflow_status.completed_at). null until the
+  // workflow reaches a terminal state.
+  completed_at: string | null;
   depth: number;
   operation_count: number;
 };

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -20,6 +20,7 @@
     status: string | null;
     started_at: string;
     updated_at: string;
+    completed_at: string | null;
     family: FamilyWorkflow[];
     steps: Step[];
     events: WorkflowEventEntry[];

--- a/packages/server/dbos_argus/data/dbos_schema.json
+++ b/packages/server/dbos_argus/data/dbos_schema.json
@@ -1,7 +1,7 @@
 {
   "schema": "dbos",
   "meta": {
-    "dbos_version": "2.21.0",
+    "dbos_version": "2.23.0",
     "note": "Full DBOS Postgres schema. `argus: true` columns are the ones the Argus backend actively reads — diff_schemas filters to those at runtime. The CI watchdog (.github/workflows/dbos-schema-watch.yml) regenerates this file against newly released DBOS versions and opens an issue when anything changes."
   },
   "tables": [
@@ -153,7 +153,8 @@
         {"name": "serialization", "data_type": "text", "argus": true},
         {"name": "delay_until_epoch_ms", "data_type": "bigint", "argus": false},
         {"name": "was_forked_from", "data_type": "boolean", "argus": false},
-        {"name": "rate_limited", "data_type": "boolean", "argus": false}
+        {"name": "rate_limited", "data_type": "boolean", "argus": false},
+        {"name": "completed_at", "data_type": "bigint", "argus": true}
       ]
     }
   ]

--- a/packages/server/dbos_argus/db/postgres.py
+++ b/packages/server/dbos_argus/db/postgres.py
@@ -142,6 +142,7 @@ def _build_workflow_sql(grouped: bool, filters: WorkflowFilters) -> tuple[str, d
                         ws.priority,
                         COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
                         ws.updated_at AS updated_ms,
+                        ws.completed_at AS completed_ms,
                         0 AS depth,
                         r.updated_at AS root_updated_at,
                         ARRAY[COALESCE(ws.started_at_epoch_ms, ws.created_at)] AS sort_path
@@ -160,6 +161,7 @@ def _build_workflow_sql(grouped: bool, filters: WorkflowFilters) -> tuple[str, d
                         c.priority,
                         COALESCE(c.started_at_epoch_ms, c.created_at),
                         c.updated_at,
+                        c.completed_at,
                         t.depth + 1,
                         t.root_updated_at,
                         t.sort_path || COALESCE(c.started_at_epoch_ms, c.created_at)
@@ -175,7 +177,7 @@ def _build_workflow_sql(grouped: bool, filters: WorkflowFilters) -> tuple[str, d
             SELECT
                 t.workflow_uuid, t.parent_workflow_id, t.name, t.status,
                 t.queue_name, t.executor_id, t.priority,
-                t.started_ms, t.updated_ms, t.depth,
+                t.started_ms, t.updated_ms, t.completed_ms, t.depth,
                 COALESCE(oc.op_count, 0)::bigint AS op_count
             FROM tree t
             LEFT JOIN op_counts oc ON oc.workflow_uuid = t.workflow_uuid
@@ -195,7 +197,8 @@ def _build_workflow_sql(grouped: bool, filters: WorkflowFilters) -> tuple[str, d
                     workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
                     priority,
                     COALESCE(started_at_epoch_ms, created_at) AS started_ms,
-                    updated_at AS updated_ms
+                    updated_at AS updated_ms,
+                    completed_at AS completed_ms
                 FROM dbos.workflow_status
                 {flat_where}
                 ORDER BY COALESCE(started_at_epoch_ms, created_at) DESC
@@ -210,7 +213,7 @@ def _build_workflow_sql(grouped: bool, filters: WorkflowFilters) -> tuple[str, d
             SELECT
                 c.workflow_uuid, c.parent_workflow_id, c.name, c.status,
                 c.queue_name, c.executor_id, c.priority,
-                c.started_ms, c.updated_ms,
+                c.started_ms, c.updated_ms, c.completed_ms,
                 0 AS depth,
                 COALESCE(oc.op_count, 0)::bigint AS op_count
             FROM chosen c
@@ -253,6 +256,7 @@ _FAMILY_SQL = """
                 ws.error IS NOT NULL AS has_error,
                 COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
                 ws.updated_at AS updated_ms,
+                ws.completed_at AS completed_ms,
                 0 AS depth,
                 ARRAY[COALESCE(ws.started_at_epoch_ms, ws.created_at)] AS sort_path
             FROM dbos.workflow_status ws
@@ -273,6 +277,7 @@ _FAMILY_SQL = """
                 c.error IS NOT NULL,
                 COALESCE(c.started_at_epoch_ms, c.created_at),
                 c.updated_at,
+                c.completed_at,
                 t.depth + 1,
                 t.sort_path || COALESCE(c.started_at_epoch_ms, c.created_at)
             FROM dbos.workflow_status c
@@ -281,7 +286,7 @@ _FAMILY_SQL = """
     SELECT
         workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
         recovery_attempts, workflow_timeout_ms,
-        has_output, has_error, started_ms, updated_ms, depth
+        has_output, has_error, started_ms, updated_ms, completed_ms, depth
     FROM tree
     ORDER BY sort_path ASC
 """
@@ -527,6 +532,7 @@ class PostgresArgusDB(ArgusDB):
                 priority=r.priority,
                 started_ms=r.started_ms,
                 updated_ms=r.updated_ms,
+                completed_ms=r.completed_ms,
                 depth=r.depth,
                 op_count=r.op_count,
             )
@@ -563,6 +569,7 @@ class PostgresArgusDB(ArgusDB):
                 has_error=r.has_error,
                 started_ms=r.started_ms,
                 updated_ms=r.updated_ms,
+                completed_ms=r.completed_ms,
                 depth=r.depth,
             )
             for r in family_rows

--- a/packages/server/dbos_argus/db/rows.py
+++ b/packages/server/dbos_argus/db/rows.py
@@ -43,6 +43,10 @@ class WorkflowListRow:
     priority: int | None
     started_ms: int
     updated_ms: int
+    # Wall-clock completion time (workflow_status.completed_at). None while the
+    # workflow is still running/enqueued, or null on rows DBOS wrote before it
+    # stamped completions.
+    completed_ms: int | None
     depth: int
     op_count: int
 
@@ -61,6 +65,9 @@ class WorkflowFamilyRow:
     has_error: bool
     started_ms: int
     updated_ms: int
+    # Wall-clock completion time (workflow_status.completed_at); None until the
+    # workflow reaches a terminal state.
+    completed_ms: int | None
     depth: int
 
 

--- a/packages/server/dbos_argus/db/sqlite.py
+++ b/packages/server/dbos_argus/db/sqlite.py
@@ -279,6 +279,7 @@ class SqliteArgusDB(ArgusDB):
                             ws.priority,
                             COALESCE(ws.started_at_epoch_ms, ws.created_at) AS started_ms,
                             ws.updated_at AS updated_ms,
+                            ws.completed_at AS completed_ms,
                             0 AS depth,
                             r.updated_at AS root_updated_at,
                             ws.workflow_uuid AS root_uuid
@@ -297,6 +298,7 @@ class SqliteArgusDB(ArgusDB):
                             c.priority,
                             COALESCE(c.started_at_epoch_ms, c.created_at),
                             c.updated_at,
+                            c.completed_at,
                             t.depth + 1,
                             t.root_updated_at,
                             t.root_uuid
@@ -306,7 +308,7 @@ class SqliteArgusDB(ArgusDB):
                 SELECT
                     t.workflow_uuid, t.parent_workflow_id, t.name, t.status,
                     t.queue_name, t.executor_id, t.priority,
-                    t.started_ms, t.updated_ms, t.depth,
+                    t.started_ms, t.updated_ms, t.completed_ms, t.depth,
                     t.root_updated_at, t.root_uuid,
                     COALESCE(oc.op_count, 0) AS op_count
                 FROM tree t
@@ -340,7 +342,8 @@ class SqliteArgusDB(ArgusDB):
                     workflow_uuid, parent_workflow_id, name, status, queue_name, executor_id,
                     priority,
                     COALESCE(started_at_epoch_ms, created_at) AS started_ms,
-                    updated_at AS updated_ms
+                    updated_at AS updated_ms,
+                    completed_at AS completed_ms
                 FROM workflow_status
                 {flat_where}
                 ORDER BY COALESCE(started_at_epoch_ms, created_at) DESC
@@ -349,7 +352,7 @@ class SqliteArgusDB(ArgusDB):
             SELECT
                 c.workflow_uuid, c.parent_workflow_id, c.name, c.status,
                 c.queue_name, c.executor_id, c.priority,
-                c.started_ms, c.updated_ms,
+                c.started_ms, c.updated_ms, c.completed_ms,
                 0 AS depth,
                 COALESCE(oc.op_count, 0) AS op_count
             FROM chosen c
@@ -376,6 +379,7 @@ class SqliteArgusDB(ArgusDB):
                 priority=r.priority,
                 started_ms=r.started_ms,
                 updated_ms=r.updated_ms,
+                completed_ms=r.completed_ms,
                 depth=r.depth,
                 op_count=r.op_count,
             )
@@ -422,6 +426,7 @@ class SqliteArgusDB(ArgusDB):
                                         COALESCE(ws.started_at_epoch_ms, ws.created_at)
                                             AS started_ms,
                                         ws.updated_at AS updated_ms,
+                                        ws.completed_at AS completed_ms,
                                         0 AS depth
                                     FROM workflow_status ws
                                     JOIN root r ON ws.workflow_uuid = r.workflow_uuid
@@ -441,6 +446,7 @@ class SqliteArgusDB(ArgusDB):
                                         c.error IS NOT NULL,
                                         COALESCE(c.started_at_epoch_ms, c.created_at),
                                         c.updated_at,
+                                        c.completed_at,
                                         t.depth + 1
                                     FROM workflow_status c
                                     JOIN tree t ON c.parent_workflow_id = t.workflow_uuid
@@ -526,6 +532,7 @@ class SqliteArgusDB(ArgusDB):
                 has_error=bool(r.has_error),
                 started_ms=r.started_ms,
                 updated_ms=r.updated_ms,
+                completed_ms=r.completed_ms,
                 depth=r.depth,
             )
             for r in family_sorted
@@ -1040,6 +1047,7 @@ def _to_workflow_list_row(r) -> WorkflowListRow:
         priority=r.priority,
         started_ms=r.started_ms,
         updated_ms=r.updated_ms,
+        completed_ms=r.completed_ms,
         depth=r.depth,
         op_count=r.op_count,
     )

--- a/packages/server/dbos_argus/main.py
+++ b/packages/server/dbos_argus/main.py
@@ -178,6 +178,11 @@ async def get_sql_diagnostics() -> SqlDiagnostics:
     )
 
 
+def _dt_from_ms(ms: int | None) -> datetime | None:
+    """Epoch-ms (DBOS' native time unit) → aware UTC datetime, or None."""
+    return datetime.fromtimestamp(ms / 1000, tz=UTC) if ms is not None else None
+
+
 class WorkflowListItem(BaseModel):
     workflow_id: str
     parent_workflow_id: str | None
@@ -189,6 +194,9 @@ class WorkflowListItem(BaseModel):
     priority: int
     started_at: datetime
     updated_at: datetime
+    # Wall-clock completion (workflow_status.completed_at). None until the
+    # workflow reaches a terminal state.
+    completed_at: datetime | None
     depth: int
     # Number of dbos.operation_outputs rows for this workflow. Computed via
     # SQL COUNT — the list endpoint never materialises individual operations.
@@ -209,6 +217,7 @@ def _to_workflow_list_item(r: WorkflowListRow) -> WorkflowListItem:
         priority=r.priority or 0,
         started_at=datetime.fromtimestamp(r.started_ms / 1000, tz=UTC),
         updated_at=datetime.fromtimestamp(r.updated_ms / 1000, tz=UTC),
+        completed_at=_dt_from_ms(r.completed_ms),
         depth=r.depth,
         operation_count=r.op_count,
     )
@@ -290,6 +299,9 @@ class WorkflowFamilyItem(BaseModel):
     workflow_timeout_ms: int | None
     started_at: datetime
     updated_at: datetime
+    # Wall-clock completion (workflow_status.completed_at). None until the
+    # workflow reaches a terminal state.
+    completed_at: datetime | None
     depth: int
     has_output: bool
     has_error: bool
@@ -324,6 +336,9 @@ class WorkflowDetail(BaseModel):
     status: str | None
     started_at: datetime
     updated_at: datetime
+    # Wall-clock completion (workflow_status.completed_at). None until the
+    # workflow reaches a terminal state.
+    completed_at: datetime | None
     # Entire workflow family rooted at the topmost ancestor, in DFS order
     # (same shape & ordering as the grouped list endpoint). Single-entry
     # when the workflow has no parent and no children.
@@ -404,6 +419,7 @@ def _build_workflow_detail(detail: WorkflowDetailRows, workflow_id: str) -> Work
             has_error=r.has_error,
             started_at=datetime.fromtimestamp(r.started_ms / 1000, tz=UTC),
             updated_at=datetime.fromtimestamp(r.updated_ms / 1000, tz=UTC),
+            completed_at=_dt_from_ms(r.completed_ms),
             depth=r.depth,
         )
         for r in detail.family
@@ -475,6 +491,7 @@ def _build_workflow_detail(detail: WorkflowDetailRows, workflow_id: str) -> Work
         status=self_item.status,
         started_at=self_item.started_at,
         updated_at=self_item.updated_at,
+        completed_at=self_item.completed_at,
         family=family,
         steps=steps,
         events=events,

--- a/packages/server/tests/integration/conftest.py
+++ b/packages/server/tests/integration/conftest.py
@@ -148,30 +148,31 @@ def _seed(sync_url: str, base_ms: int) -> dict[str, object]:
                     INSERT INTO {p}workflow_status
                         (workflow_uuid, status, name, executor_id, created_at, updated_at,
                          recovery_attempts, started_at_epoch_ms, priority,
-                         parent_workflow_id, output, error, serialization, queue_name)
+                         parent_workflow_id, output, error, serialization, queue_name,
+                         completed_at)
                     VALUES
                         ('wf-root', 'PENDING', 'root_workflow', 'test',
-                         :t0, :t0, 0, :t0, 0, NULL, NULL, NULL, 'portable_json', NULL),
+                         :t0, :t0, 0, :t0, 0, NULL, NULL, NULL, 'portable_json', NULL, NULL),
                         ('wf-child-success', 'SUCCESS', 'child_a', 'test',
                          :t1, :t1, 0, :t1, 0, 'wf-root', '"hello"', NULL,
-                         'portable_json', NULL),
+                         'portable_json', NULL, :c1),
                         ('wf-child-pending', 'PENDING', 'child_b', 'test',
-                         :t2, :t2, 0, :t2, 0, 'wf-root', NULL, NULL, 'portable_json', NULL),
+                         :t2, :t2, 0, :t2, 0, 'wf-root', NULL, NULL, 'portable_json', NULL, NULL),
                         ('wf-grandchild-error', 'ERROR', 'grandchild', 'test',
                          :t3, :t3, 0, :t3, 0, 'wf-child-success', NULL, '"boom"',
-                         'portable_json', NULL),
+                         'portable_json', NULL, :c3),
                         ('wf-q-hb-enq', 'ENQUEUED', 'queued_a', 'test',
                          :t4, :t4, 0, NULL, 0, NULL, NULL, NULL,
-                         'portable_json', 'argus-heartbeats'),
+                         'portable_json', 'argus-heartbeats', NULL),
                         ('wf-q-hb-pend', 'PENDING', 'queued_b', 'test',
                          :t5, :t5, 0, :t5, 0, NULL, NULL, NULL,
-                         'portable_json', 'argus-heartbeats'),
+                         'portable_json', 'argus-heartbeats', NULL),
                         ('wf-q-plain-enq', 'ENQUEUED', 'queued_c', 'test',
                          :t6, :t6, 0, NULL, 0, NULL, NULL, NULL,
-                         'portable_json', 'plain-queue'),
+                         'portable_json', 'plain-queue', NULL),
                         ('wf-q-orphan-enq', 'ENQUEUED', 'queued_d', 'test',
                          :t7, :t7, 0, NULL, 0, NULL, NULL, NULL,
-                         'portable_json', 'orphaned-queue')
+                         'portable_json', 'orphaned-queue', NULL)
                     """
                 ),
                 {
@@ -183,6 +184,11 @@ def _seed(sync_url: str, base_ms: int) -> dict[str, object]:
                     "t5": base_ms + 500,
                     "t6": base_ms + 600,
                     "t7": base_ms + 700,
+                    # Terminal workflows carry completed_at; PENDING/ENQUEUED
+                    # rows leave it NULL. wf-child-success finishes 150ms after
+                    # it started (t1), the errored grandchild 50ms after t3.
+                    "c1": base_ms + 250,
+                    "c3": base_ms + 350,
                 },
             )
             # operation_outputs: an audit, a setEvent (joined to events_history

--- a/packages/server/tests/integration/test_db_adapter.py
+++ b/packages/server/tests/integration/test_db_adapter.py
@@ -121,6 +121,27 @@ async def test_get_workflow_detail_returns_family_steps_events(populated_db: DB)
     assert any(e.key == "demo" for e in detail.events)
 
 
+async def test_completed_at_terminal_vs_running(populated_db: DB) -> None:
+    """workflow_status.completed_at (DBOS 2.23.0+) flows through both the
+    detail family rows and the list rows: populated on terminal workflows,
+    NULL while still running."""
+    db, seed = populated_db
+    base_ms = int(seed["base_ms"])
+
+    detail = await db.get_workflow_detail(seed["child_success_id"])
+    fam = {f.workflow_uuid: f for f in detail.family}
+    # SUCCESS finished 150ms after start; ERROR grandchild 50ms after its start.
+    assert fam[seed["child_success_id"]].completed_ms == base_ms + 250
+    assert fam[seed["grandchild_error_id"]].completed_ms == base_ms + 350
+    # Still-running workflows have no completion stamp yet.
+    assert fam[seed["root_id"]].completed_ms is None
+    assert fam[seed["child_pending_id"]].completed_ms is None
+
+    # Same column surfaces on the list path.
+    rows = await db.list_workflows(WorkflowFilters(grouped=False, statuses=["SUCCESS"]))
+    assert rows[0].completed_ms == base_ms + 250
+
+
 async def test_get_workflow_detail_unknown_returns_empty(populated_db: DB) -> None:
     db, _ = populated_db
     detail = await db.get_workflow_detail("does-not-exist")

--- a/tests/sample-app/pyproject.toml
+++ b/tests/sample-app/pyproject.toml
@@ -5,8 +5,9 @@ description = "Sample DBOS Transact app — dev fixture for the Argus dashboard.
 requires-python = ">=3.12"
 dependencies = [
   "click>=8.1.0",
-  # 2.21.0 introduced the `dbos.queues` registry table that Argus reads.
-  "dbos>=2.21.0",
+  # Argus tracks the latest DBOS schema (no backward compat). 2.23.0 added
+  # `dbos.workflow_status.completed_at`, which Argus reads for completion time.
+  "dbos>=2.23.0",
   "python-dotenv>=1.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
-    { name = "dbos", specifier = ">=2.21.0" },
+    { name = "dbos", specifier = ">=2.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
@@ -204,19 +204,19 @@ wheels = [
 
 [[package]]
 name = "dbos"
-version = "2.21.0"
+version = "2.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dateutil" },
     { name = "pyyaml" },
-    { name = "sqlalchemy" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "typer-slim" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/48/a0c19e5a369ee5ddb88585dd6c4eba938789d50bbc2e144526b2c85f944c/dbos-2.21.0.tar.gz", hash = "sha256:89896b4f4ee31a7ae8463cdb512b4c2029a68f9667fdaa90ebe980d13d4dd915", size = 465138, upload-time = "2026-05-07T16:30:59.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/7b/65e8626661a9fd7022c888d8faddbd49887106e95a30f10b6ea4ea71fd3f/dbos-2.23.0.tar.gz", hash = "sha256:4cd3f8f2dca3c1b97dfc391f0ae539ff56646e381adbf9860ddba6d4e6114198", size = 495782, upload-time = "2026-06-01T21:36:10.399Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/58/072e39d245a37793649711839b1fc4b61827747c7b1c4ab8e02309475c17/dbos-2.21.0-py3-none-any.whl", hash = "sha256:9dd0a39172716972532cfa4b348fd6f8371c10b250b7030f05ca95d53f71f214", size = 189715, upload-time = "2026-05-07T16:30:58.254Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1a/1a45caeb874b1a0eae0baeb817ddfdff53fb15bd17e8c875f223b82febb7/dbos-2.23.0-py3-none-any.whl", hash = "sha256:1cf9c21a23a39b90739cd52e79bac7432ae94428c6802574901d1e0e22371459", size = 205652, upload-time = "2026-06-01T21:36:08.744Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #10 (dbos-watch drift: DBOS 2.21.0 → 2.23.0).

DBOS 2.23.0 added `dbos.workflow_status.completed_at` — the canonical wall-clock timestamp for when a workflow reached a terminal state. This adopts it end to end.

## Version alignment
Argus tracks the **latest** DBOS schema and does not aim for backward compatibility. This raises the dependency floor to `dbos>=2.23.0` and bumps the schema snapshot to 2.23.0. Pointing Argus at an older DBOS database whose `workflow_status` lacks `completed_at` will error on the workflow list/detail reads — that tradeoff is called out in the `[Unreleased]` CHANGELOG callout and the `tested_dbos_version` banner.

## Changes
- **Schema snapshot** regenerated to 2.23.0; `completed_at` flipped to `argus: true`. Matches the watchdog regenerator output, so the daily drift check goes quiet.
- **Adapters** (Postgres + SQLite, in lockstep): select `completed_at` into `WorkflowListRow` / `WorkflowFamilyRow` across the list (grouped + flat) and detail (family CTE) queries.
- **API / realtime**: `completed_at` added to `WorkflowListItem`, `WorkflowFamilyItem`, and `WorkflowDetail`. Realtime channels reuse the same `main.py` mappers, so both transports stay identical.
- **Console**: workflow detail pane shows a **Completed** row and computes **Duration** from `started_at → completed_at`, falling back to `updated_at` while still running. Null until terminal.
- **Dependency**: `dbos>=2.23.0` in the sample app + relocked.

## Testing
- `pnpm run lint` and `pnpm run build` clean across all workspaces.
- Server suite (87) green; integration suite seeds `completed_at` and asserts the read path on terminal vs running workflows.
- Integration suite re-run against **real Postgres** (21 passed), validating the recursive-CTE column additions on the production path.