### PR TITLE
Tell users which Argus version fits their DBOS database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Tested against DBOS 2.27.0.** See `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility.
+
+## [0.0.32] - 2026-07-25
+
+> **Tested against DBOS 2.27.0.** Requires DBOS schema revision 41 (Postgres) / 36 (SQLite) — see `required_dbos_schema_revision` in `GET /version`, or the compatibility table in [README.md](./README.md#which-argus-version-do-i-need). Argus tracks the latest DBOS schema and does not aim for backward compatibility.
+
+### Added
+- **Version compatibility advice.** Pointing Argus at a database migrated by an
+  older DBOS release used to fail with an opaque "column does not exist". Argus
+  now reads DBOS' own schema revision counter (`dbos.dbos_migrations.version`)
+  and, when the database is behind what this build queries, names the newest
+  Argus release that does work — e.g. `pip install 'dbos-argus==0.0.28'` — plus
+  the DBOS version to upgrade to instead. Surfaced in the console's connection
+  panel, on `GET /api/sql-diagnostics` under a new `compat` object, and as a
+  compatibility table in the README.
+  - The revision counter is used rather than the `dbos` package version because
+    the package version isn't recorded in the database at all
+    (`dbos.application_versions` holds the *host app's* version), and can
+    disagree with the database when the library is upgraded without the app
+    re-running its migrations.
+  - Floors are tracked per dialect: DBOS' Postgres and SQLite migration lists
+    diverge, so the current requirement is revision 41 on Postgres and 36 on
+    SQLite.
+  - A database with no `dbos_migrations` table (fresh, or legacy
+    Alembic-managed) is not graded — the existing column diff remains the
+    authority there.
+- `GET /version` reports `required_dbos_schema_revision`, and
+  `dbos-argus --version` prints the per-dialect floors. Neither needs a
+  database connection.
+
+### Changed
+- `inspect_dbos_schema()` returns a `DbosSchemaReport` (issues + compat report)
+  rather than a bare list of issues. Internal API; the REST shape is additive.
+- The connection panel's generic "likely an older version of DBOS" note is now
+  suppressed when the revision check has already given a definite answer.
+
+### Internal
+- CI guards the compatibility ladder from both directions. The SQLite floor is
+  proven exactly by replaying DBOS' SQLite migrations in memory; the Postgres
+  floor by migrating a throwaway schema with DBOS' real DDL on the `postgres`
+  matrix leg. Both assert the declared floor is the *lowest* revision providing
+  every argus-tracked column, so adopting a column without bumping the ladder
+  fails CI, as does bumping it too far. A further test keeps the README
+  compatibility table in sync with the ladder.
+- Running the suite without a Postgres server emits an explicit warning that
+  the Postgres floor went unverified, rather than a silent skip.
+
 ## [0.0.31] - 2026-07-17
 
 > **Tested against DBOS 2.27.0.** See `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility; the dev fixture floor is now `dbos>=2.27.0`.
@@ -662,7 +709,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workflow detail page with parent/child family DFS view, step timelines, lazy-loaded outputs, and `DBOS.sleep` / `DBOS.setEvent` decoding.
 - Single-stage Docker image at `tmarkovski/dbos-argus`, multi-arch (amd64/arm64), installed straight from PyPI.
 
-[Unreleased]: https://github.com/tmarkovski/dbos-argus/compare/v0.0.31...HEAD
+[Unreleased]: https://github.com/tmarkovski/dbos-argus/compare/v0.0.32...HEAD
+[0.0.32]: https://github.com/tmarkovski/dbos-argus/releases/tag/v0.0.32
 [0.0.31]: https://github.com/tmarkovski/dbos-argus/releases/tag/v0.0.31
 [0.0.30]: https://github.com/tmarkovski/dbos-argus/releases/tag/v0.0.30
 [0.0.29]: https://github.com/tmarkovski/dbos-argus/releases/tag/v0.0.29

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,25 @@ uv run --with asyncpg --with sqlalchemy \
 
 **When you adopt a new DBOS column** (flipping `argus: true` and adding a query in `main.py`), bump it in the snapshot directly. The watchdog only carries flags forward — it never sets `argus: true`.
 
+### Bumping the compatibility floor
+
+Adopting a column that arrived in a newer DBOS migration raises the minimum DBOS schema revision Argus can read, so `packages/server/dbos_argus/compat.py` needs a matching edit. That file maps `dbos.dbos_migrations.version` (DBOS' own migration counter) to the newest Argus release that works against it — it's what tells a user on an older DBOS to `pip install 'dbos-argus==0.0.28'` instead of hitting an opaque "column does not exist".
+
+1. Find the migration ordinal that introduces the column, **per dialect** (the two lists diverge, so the numbers differ):
+
+   ```bash
+   uv run python -c '
+   from dbos import _migration as m
+   col = "schedule_name"   # the column you just adopted
+   for label, lst in (("postgres", m.get_dbos_migrations("dbos", True, False)), ("sqlite", m.sqlite_migrations)):
+       hits = [i for i, s in enumerate(lst, 1) if f"ADD COLUMN IF NOT EXISTS \"{col}\"" in s or f"ADD COLUMN \"{col}\"" in s]
+       print(label, hits)'
+   ```
+
+2. In `compat.py`, set the previously-final `CompatStep`'s `max_argus_version` to the last released Argus version (the newest one that still works *without* the new column), then append a new step with the ordinals from step 1, the DBOS version that shipped them, and the column in `requires`.
+3. Add the new row to the table in README.md → "Which Argus version do I need?".
+4. `uv run pytest packages/server/tests/test_compat.py`. `test_declared_sqlite_floor_is_exact` replays DBOS' real SQLite migrations and fails if the declared floor is either too low (a column isn't there yet) or higher than necessary, so a forgotten or mistyped bump is caught here rather than by a user.
+
 ## Releasing
 
 Releases are tag-driven — pushing a `v*` tag fires `.github/workflows/release.yml`, which publishes to PyPI, builds and pushes the multi-arch Docker image, and creates the GitHub Release.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,30 @@ Argus is a web dashboard for visualizing the durable workflows your [DBOS Transa
 
 > **Status:** Pre-alpha. Everything will change. Not production-ready. Argus is built for development and quick inspection of a running DBOS database.
 
-> **DBOS compatibility.** Each release is validated against a specific DBOS version — see the "Tested against DBOS …" line in [CHANGELOG.md](./CHANGELOG.md) (and in the release notes on the [Releases page](https://github.com/tmarkovski/dbos-argus/releases)), or call `GET /version` (`tested_dbos_version`) on a running instance. Older / newer DBOS versions usually still work; the connection sidebar in the UI flags any schema mismatches it finds.
+> **DBOS compatibility.** Argus grades your database automatically. It reads DBOS Transact's own schema revision counter (`dbos.dbos_migrations.version`) and, if your database is older than the columns Argus queries, the connection sidebar tells you which Argus version to install instead. See [Which Argus version do I need?](#which-argus-version-do-i-need) below.
+
+---
+
+## Which Argus version do I need?
+
+Argus reads DBOS's system tables directly, so a database migrated by an older DBOS release can be missing a column Argus queries. Rather than matching version numbers, Argus checks the migration counter DBOS maintains in its own schema:
+
+```bash
+psql "$ARGUS_DATABASE_URL" -c 'SELECT version FROM dbos.dbos_migrations'
+```
+
+| Your `dbos_migrations.version` | | Use Argus | Because it reads |
+|---|---|---|---|
+| Postgres | SQLite | | |
+| ≥ 41 | ≥ 36 | latest | — |
+| 36 – 40 | 33 – 35 | `0.0.28` | `workflow_status.attributes`, `.schedule_name` |
+| < 36 | < 33 | `0.0.27` | `workflow_status.completed_at` |
+
+Postgres and SQLite have separate counters because DBOS's migration lists for the two dialects diverge, so the same number means different things on each backend.
+
+You do not have to look this up by hand. Open the connection panel in the console (click the database indicator in the sidebar): if the database is behind, it names the exact `pip install` line and the DBOS version to upgrade to instead. The same verdict is on `GET /api/sql-diagnostics` under `compat`, and `GET /version` reports the revision this build requires without touching the database.
+
+Each release is also validated end to end against a specific DBOS version — see the "Tested against DBOS …" line in [CHANGELOG.md](./CHANGELOG.md), or `tested_dbos_version` on `GET /version`.
 
 ---
 

--- a/apps/console/src/lib/connection-diagnostics.test.ts
+++ b/apps/console/src/lib/connection-diagnostics.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  argusPinCommand,
   connectionIndicatorClass,
   connectionIndicatorLabel,
+  dbosCompatOutdated,
   diagnosticsIssueSummary,
   getConnectionIndicatorState,
+  type DbosCompat,
   type Health,
   type SqlDiagnostics,
 } from "./connection-diagnostics.js";
@@ -12,6 +15,28 @@ import {
 const connectedHealth: Health = {
   status: "ok",
   database: "up",
+};
+
+const compatibleCompat: DbosCompat = {
+  dialect: "postgres",
+  revision: 41,
+  required_revision: 41,
+  compatible: true,
+  recommended_argus_version: null,
+  recommended_dbos_version: null,
+  missing_columns: [],
+  message: null,
+};
+
+const outdatedCompat: DbosCompat = {
+  dialect: "postgres",
+  revision: 38,
+  required_revision: 41,
+  compatible: false,
+  recommended_argus_version: "0.0.28",
+  recommended_dbos_version: "2.25.0",
+  missing_columns: ["workflow_status.attributes", "workflow_status.schedule_name"],
+  message: "This database is at DBOS schema revision 38; Argus needs 41.",
 };
 
 describe("connection diagnostics helpers", () => {
@@ -71,5 +96,72 @@ describe("connection diagnostics helpers", () => {
     expect(connectionIndicatorClass("connected")).toBe("text-status-success");
     expect(connectionIndicatorLabel("connected")).toBe("Connected");
     expect(diagnosticsIssueSummary({ ok: true, issues: [] })).toBeNull();
+  });
+});
+
+describe("DBOS revision compatibility", () => {
+  it("flags an outdated revision even when no columns are reported missing", () => {
+    const diagnostics: SqlDiagnostics = { ok: true, issues: [], compat: outdatedCompat };
+
+    expect(
+      getConnectionIndicatorState({
+        fetchError: null,
+        health: connectedHealth,
+        diagnostics,
+      }),
+    ).toBe("issues");
+    expect(dbosCompatOutdated(diagnostics)).toEqual(outdatedCompat);
+    expect(diagnosticsIssueSummary(diagnostics)).toBe(
+      "DBOS schema revision 38 — Argus needs 41",
+    );
+  });
+
+  it("prefers the revision verdict over the raw issue count", () => {
+    // Both are the same underlying problem; the pin advice is the useful half.
+    const diagnostics: SqlDiagnostics = {
+      ok: false,
+      issues: [
+        {
+          kind: "missing_column",
+          table_name: "workflow_status",
+          column_name: "schedule_name",
+          expected_type: "text",
+          actual_type: null,
+          detail: "Missing required column dbos.workflow_status.schedule_name.",
+        },
+      ],
+      compat: outdatedCompat,
+    };
+
+    expect(diagnosticsIssueSummary(diagnostics)).toBe(
+      "DBOS schema revision 38 — Argus needs 41",
+    );
+  });
+
+  it("stays quiet when the revision is current, unknown, or ungraded", () => {
+    const current: SqlDiagnostics = { ok: true, issues: [], compat: compatibleCompat };
+    // No dbos_migrations table to read: a legacy Alembic-managed database.
+    const unknown: SqlDiagnostics = {
+      ok: true,
+      issues: [],
+      compat: { ...compatibleCompat, revision: null },
+    };
+    // An older server that predates the compat field.
+    const ungraded: SqlDiagnostics = { ok: true, issues: [] };
+
+    for (const diagnostics of [current, unknown, ungraded]) {
+      expect(dbosCompatOutdated(diagnostics)).toBeNull();
+      expect(diagnosticsIssueSummary(diagnostics)).toBeNull();
+      expect(
+        getConnectionIndicatorState({ fetchError: null, health: connectedHealth, diagnostics }),
+      ).toBe("connected");
+    }
+    expect(dbosCompatOutdated(null)).toBeNull();
+  });
+
+  it("builds a copy-pasteable pin command", () => {
+    expect(argusPinCommand(outdatedCompat)).toBe("pip install 'dbos-argus==0.0.28'");
+    expect(argusPinCommand(compatibleCompat)).toBeNull();
+    expect(argusPinCommand(null)).toBeNull();
   });
 });

--- a/apps/console/src/lib/connection-diagnostics.ts
+++ b/apps/console/src/lib/connection-diagnostics.ts
@@ -28,9 +28,29 @@ export type SqlDiagnosticIssue = {
   detail: string;
 };
 
+/**
+ * DBOS schema-revision grading, from `dbos.dbos_migrations.version`.
+ *
+ * `compatible` is false only when the revision is known *and* below what this
+ * Argus build needs. A null `revision` (no migrations table: fresh DB, or a
+ * legacy Alembic-managed one) makes no claim and stays compatible — `issues` is
+ * the authority there.
+ */
+export type DbosCompat = {
+  dialect: "postgres" | "sqlite";
+  revision: number | null;
+  required_revision: number;
+  compatible: boolean;
+  recommended_argus_version: string | null;
+  recommended_dbos_version: string | null;
+  missing_columns: string[];
+  message: string | null;
+};
+
 export type SqlDiagnostics = {
   ok: boolean;
   issues: SqlDiagnosticIssue[];
+  compat?: DbosCompat;
 };
 
 export type ConnectionIndicatorState = "connected" | "issues" | "disconnected";
@@ -45,7 +65,12 @@ export function getConnectionIndicatorState({
   diagnostics: SqlDiagnostics | null;
 }): ConnectionIndicatorState {
   if (fetchError || health?.database !== "up") return "disconnected";
-  if (diagnostics && !diagnostics.ok) return "issues";
+  // A stale revision normally shows up as missing columns too, but grade it
+  // explicitly so the indicator can't read green on a DB we've already judged
+  // too old.
+  if (diagnostics && (!diagnostics.ok || diagnostics.compat?.compatible === false)) {
+    return "issues";
+  }
   return "connected";
 }
 
@@ -60,7 +85,33 @@ export function connectionIndicatorLabel(state: ConnectionIndicatorState): strin
 }
 
 export function diagnosticsIssueSummary(diagnostics: SqlDiagnostics | null): string | null {
-  if (!diagnostics || diagnostics.ok) return null;
+  if (!diagnostics) return null;
+  // The revision verdict outranks the column count: it's the same underlying
+  // problem stated in the form the user can act on.
+  const outdated = dbosCompatOutdated(diagnostics);
+  if (outdated) {
+    return `DBOS schema revision ${outdated.revision} — Argus needs ${outdated.required_revision}`;
+  }
+  if (diagnostics.ok) return null;
   const count = diagnostics.issues.length;
   return `${count} schema issue${count === 1 ? "" : "s"} found`;
+}
+
+/**
+ * The compat report, but only when it's a definite "your DB is too old" verdict
+ * with a known revision. Returns null when compatible, absent, or ungraded, so
+ * callers can treat a truthy result as "render the pin advice".
+ */
+export function dbosCompatOutdated(
+  diagnostics: SqlDiagnostics | null,
+): (DbosCompat & { revision: number }) | null {
+  const compat = diagnostics?.compat;
+  if (!compat || compat.compatible || compat.revision === null) return null;
+  return compat as DbosCompat & { revision: number };
+}
+
+/** `pip install 'dbos-argus==0.0.28'`, or null when there's nothing to pin. */
+export function argusPinCommand(compat: DbosCompat | null): string | null {
+  if (!compat?.recommended_argus_version) return null;
+  return `pip install 'dbos-argus==${compat.recommended_argus_version}'`;
 }

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -13,8 +13,10 @@
   import { page } from "$app/state";
   import { breadcrumb } from "$lib/breadcrumb.svelte";
   import {
+    argusPinCommand,
     connectionIndicatorClass,
     connectionIndicatorLabel,
+    dbosCompatOutdated,
     diagnosticsIssueSummary,
     formatDialectLabel,
     getConnectionIndicatorState,
@@ -177,6 +179,11 @@
     ),
   );
   const dbSchemaRev = $derived(connectionState.health?.dbos_schema_revision ?? null);
+  // Non-null only when the server graded this DB's revision as too old for the
+  // running Argus build; carries the version to pin and the DBOS version to
+  // upgrade to instead.
+  const dbCompatOutdated = $derived(dbosCompatOutdated(connectionState.diagnostics));
+  const dbPinCommand = $derived(argusPinCommand(dbCompatOutdated));
 </script>
 
 <Sidebar.Provider bind:open={sidebarOpen} onOpenChange={persistSidebarOpen}>
@@ -333,10 +340,61 @@
                         >
                           DBOS schema revision
                         </dt>
-                        <dd class="font-mono text-xs">{dbSchemaRev}</dd>
+                        <dd class="font-mono text-xs">
+                          {dbSchemaRev}
+                          {#if dbCompatOutdated}
+                            <span class="text-status-warning"
+                              >/ {dbCompatOutdated.required_revision} needed</span
+                            >
+                          {/if}
+                        </dd>
                       </div>
                     {/if}
                   </dl>
+                {/if}
+
+                {#if dbCompatOutdated}
+                  <div
+                    class="border-status-warning/40 bg-status-warning/5 flex flex-col gap-3 rounded-lg border p-4"
+                  >
+                    <div class="flex flex-col gap-1.5">
+                      <span class="text-status-warning text-xs uppercase tracking-wide">
+                        Argus version mismatch
+                      </span>
+                      <p class="text-sm">
+                        This database was migrated by an older DBOS release than this Argus
+                        build supports. Upgrade DBOS to
+                        <span class="font-mono text-xs"
+                          >{dbCompatOutdated.recommended_dbos_version}</span
+                        >
+                        or newer and let your app run its migrations, or downgrade Argus.
+                      </p>
+                    </div>
+
+                    {#if dbPinCommand}
+                      <div class="flex flex-col gap-1.5">
+                        <span class="text-muted-foreground text-xs uppercase tracking-wide">
+                          Last Argus release that supports this database
+                        </span>
+                        <p class="bg-muted/40 rounded px-2 py-1.5 font-mono text-xs break-all">
+                          {dbPinCommand}
+                        </p>
+                      </div>
+                    {/if}
+
+                    {#if dbCompatOutdated.missing_columns.length > 0}
+                      <div class="flex flex-col gap-1.5">
+                        <span class="text-muted-foreground text-xs uppercase tracking-wide">
+                          Columns Argus needs that this database lacks
+                        </span>
+                        <ul class="flex flex-col gap-0.5">
+                          {#each dbCompatOutdated.missing_columns as column (column)}
+                            <li class="font-mono text-xs">dbos.{column}</li>
+                          {/each}
+                        </ul>
+                      </div>
+                    {/if}
+                  </div>
                 {/if}
 
                 {#if dbConnected}
@@ -396,15 +454,19 @@
                             </Table.Body>
                           </Table.Root>
                         </div>
-                        <div class="flex flex-col gap-1.5">
-                          <span class="text-muted-foreground text-xs uppercase tracking-wide">
-                            Note
-                          </span>
-                          <p class="text-muted-foreground text-sm">
-                            This is likely due to an older version of DBOS than Argus currently
-                            expects.
-                          </p>
-                        </div>
+                        {#if !dbCompatOutdated}
+                          <!-- Only guess when the revision check didn't already
+                               give a definite answer above. -->
+                          <div class="flex flex-col gap-1.5">
+                            <span class="text-muted-foreground text-xs uppercase tracking-wide">
+                              Note
+                            </span>
+                            <p class="text-muted-foreground text-sm">
+                              This is likely due to an older version of DBOS than Argus currently
+                              expects.
+                            </p>
+                          </div>
+                        {/if}
                       {/if}
                     {/if}
                   </div>

--- a/packages/server/dbos_argus/cli.py
+++ b/packages/server/dbos_argus/cli.py
@@ -14,16 +14,27 @@ import click
 import uvicorn
 
 from . import __version__
+from .compat import required_revision
 from .schema_dump import load_full_dump
 
 
 def _version_message() -> str:
-    """`dbos-argus X.Y.Z (tested against DBOS Y.Y.Y)` for `--version`."""
+    """`dbos-argus X.Y.Z (tested against DBOS Y.Y.Y, needs schema revision N)`.
+
+    The revision is the actionable half: it's what `dbos.dbos_migrations.version`
+    must reach for this build's queries to work, and it's printable without a
+    database connection.
+    """
     try:
         tested = load_full_dump().meta.get("dbos_version", "unknown")
     except Exception:
         tested = "unknown"
-    return f"%(prog)s %(version)s (tested against DBOS {tested})"
+    pg = required_revision("postgres")
+    sqlite = required_revision("sqlite")
+    return (
+        f"%(prog)s %(version)s (tested against DBOS {tested}; "
+        f"needs dbos_migrations.version >= {pg} on Postgres, >= {sqlite} on SQLite)"
+    )
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/packages/server/dbos_argus/compat.py
+++ b/packages/server/dbos_argus/compat.py
@@ -1,0 +1,192 @@
+"""DBOS schema-revision compatibility.
+
+Argus reads a moving set of `dbos.*` columns, so a database last migrated by an
+older DBOS release can be missing something Argus queries — the symptom is an
+opaque "column does not exist" error on the workflow list or detail page. This
+module turns that into an actionable instruction: *pin Argus to version X*.
+
+The signal is `dbos.dbos_migrations.version`, DBOS Transact's own schema
+revision counter — a 1-based count of applied migrations (DBOS applies them with
+`enumerate(migrations, 1)`) that only ever grows. That integer, not the `dbos`
+package version, is the right key:
+
+- The package version is not in the database at all. `dbos.application_versions`
+  holds the *host application's* version, not DBOS'.
+- The package version can lie. Upgrading `dbos` without restarting the app that
+  runs the migrations leaves the database behind what the library advertises.
+- A missing column is a migration fact, so the migration counter answers the
+  question directly instead of by proxy.
+
+Revisions are **per-dialect**. DBOS' Postgres and SQLite migration lists diverge
+(SQLite has no counterpart for a handful of Postgres-only migrations), so the
+same integer means different things on each backend and every floor below is
+recorded twice.
+
+Maintenance
+-----------
+When `main.py` starts reading a column that arrived in a newer DBOS migration:
+
+1. Flip the column to `"argus": true` in `data/dbos_schema.json`.
+2. Append a `CompatStep` below with the new per-dialect revisions, and set the
+   previously-final step's `max_argus_version` to the last released Argus
+   version — the newest one that still works without the new column.
+
+`test_compat.py` asserts the ladder stays internally consistent and that the
+final step matches what the snapshot actually requires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Dialect = Literal["postgres", "sqlite"]
+
+__all__ = [
+    "COMPAT_STEPS",
+    "CompatReport",
+    "CompatStep",
+    "Dialect",
+    "required_revision",
+    "resolve_compat",
+]
+
+
+@dataclass(frozen=True)
+class CompatStep:
+    """One point in Argus' history where the required DBOS schema revision rose.
+
+    `max_argus_version` is the newest Argus release that runs against a database
+    sitting at this step — i.e. the version to pin. It is `None` on the final
+    step, which is the requirement the current build enforces: a database that
+    reaches it needs no pin at all.
+    """
+
+    postgres: int
+    sqlite: int
+    max_argus_version: str | None
+    # DBOS release that first shipped these revisions. Human-readable hint only;
+    # never used for comparisons.
+    dbos_version: str
+    # Columns this step started reading, as `table.column`, for the message.
+    requires: tuple[str, ...]
+
+    def revision_for(self, dialect: Dialect) -> int:
+        return self.sqlite if dialect == "sqlite" else self.postgres
+
+
+# Ascending by revision. See "Maintenance" above before editing.
+COMPAT_STEPS: tuple[CompatStep, ...] = (
+    CompatStep(
+        postgres=0,
+        sqlite=0,
+        max_argus_version="0.0.27",
+        dbos_version="2.19.0",
+        requires=(),
+    ),
+    CompatStep(
+        postgres=36,
+        sqlite=33,
+        max_argus_version="0.0.28",
+        dbos_version="2.23.0",
+        requires=("workflow_status.completed_at",),
+    ),
+    CompatStep(
+        postgres=41,
+        sqlite=36,
+        max_argus_version=None,
+        dbos_version="2.25.0",
+        requires=("workflow_status.attributes", "workflow_status.schedule_name"),
+    ),
+)
+
+
+def required_revision(dialect: Dialect) -> int:
+    """Lowest `dbos_migrations.version` this Argus build can read."""
+    return COMPAT_STEPS[-1].revision_for(dialect)
+
+
+@dataclass(frozen=True)
+class CompatReport:
+    dialect: Dialect
+    # None when `dbos_migrations` is absent or unreadable: either a fresh
+    # database no DBOS app has migrated yet, or a legacy Alembic-managed one
+    # that predates the migrations table. Both leave the column diff as the
+    # only authority, so we make no claim.
+    revision: int | None
+    required_revision: int
+    # False only when the revision is known *and* below what Argus needs.
+    compatible: bool
+    # Newest Argus release that works against this database. None when the
+    # database is already current (or its revision is unknown).
+    recommended_argus_version: str | None
+    # DBOS release to upgrade to as the alternative to pinning Argus.
+    recommended_dbos_version: str | None
+    # `table.column` entries Argus reads that this database cannot have.
+    missing_columns: tuple[str, ...]
+    # Populated iff `compatible` is False.
+    message: str | None
+
+
+def resolve_compat(dialect: Dialect, revision: int | None) -> CompatReport:
+    """Compare a database's DBOS schema revision against what Argus requires.
+
+    Returns a compatible report when `revision` is None — an unknown revision is
+    not evidence of a problem, and `sql_diagnostics` still reports the concrete
+    missing columns.
+    """
+    required = required_revision(dialect)
+
+    if revision is None or revision >= required:
+        return CompatReport(
+            dialect=dialect,
+            revision=revision,
+            required_revision=required,
+            compatible=True,
+            recommended_argus_version=None,
+            recommended_dbos_version=None,
+            missing_columns=(),
+            message=None,
+        )
+
+    # Newest step this database satisfies decides the pin; every step above it
+    # is unmet, so their columns are collectively missing.
+    satisfied = COMPAT_STEPS[0]
+    unmet: list[CompatStep] = []
+    for step in COMPAT_STEPS:
+        if revision >= step.revision_for(dialect):
+            satisfied = step
+        else:
+            unmet.append(step)
+
+    # The upgrade advice names the DBOS version that clears *every* unmet step,
+    # not just the next one — the final step is Argus' actual requirement, so
+    # anything lower would leave the user still broken after upgrading.
+    target = COMPAT_STEPS[-1]
+    missing = [column for step in unmet for column in step.requires]
+
+    pin = satisfied.max_argus_version
+    columns = ", ".join(missing)
+    remedy = f"upgrade DBOS to {target.dbos_version} or newer and let your app run its migrations"
+    if pin is None:
+        # Unreachable with the current ladder (only the final step carries
+        # None, and reaching it means compatible). Kept so a future edit that
+        # sets None on a middle step degrades to advice instead of a crash.
+        pin_advice = "no earlier Argus release is recorded for this revision"
+    else:
+        pin_advice = f"pin Argus with `pip install 'dbos-argus=={pin}'`"
+
+    return CompatReport(
+        dialect=dialect,
+        revision=revision,
+        required_revision=required,
+        compatible=False,
+        recommended_argus_version=pin,
+        recommended_dbos_version=target.dbos_version,
+        missing_columns=tuple(missing),
+        message=(
+            f"This database is at DBOS schema revision {revision}; "
+            f"Argus needs {required}. Missing: {columns}. "
+            f"Either {remedy}, or {pin_advice}."
+        ),
+    )

--- a/packages/server/dbos_argus/main.py
+++ b/packages/server/dbos_argus/main.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
 
 from . import __version__
+from .compat import required_revision
 from .db import db
 from .db.rows import (
     NotificationFilters,
@@ -139,6 +140,10 @@ async def version() -> dict[str, str]:
     return {
         "version": __version__,
         "tested_dbos_version": str(snapshot.meta.get("dbos_version", "unknown")),
+        # Lowest dbos.dbos_migrations.version this build can read, per dialect.
+        # Reported unconditionally (no DB access) so `curl /version` is enough to
+        # answer "will this Argus work against my database?" offline.
+        "required_dbos_schema_revision": str(required_revision(db.dialect)),
     }
 
 
@@ -151,19 +156,37 @@ class SqlDiagnosticIssue(BaseModel):
     detail: str
 
 
+class DbosCompat(BaseModel):
+    """DBOS schema revision grading. `compatible` is False only when the
+    revision is known and below what this Argus build requires; an unreadable
+    revision (`revision: null`) makes no claim and leaves `issues` as the
+    authority."""
+
+    dialect: Literal["postgres", "sqlite"]
+    revision: int | None
+    required_revision: int
+    compatible: bool
+    recommended_argus_version: str | None
+    recommended_dbos_version: str | None
+    missing_columns: list[str]
+    message: str | None
+
+
 class SqlDiagnostics(BaseModel):
     ok: bool
     issues: list[SqlDiagnosticIssue]
+    compat: DbosCompat
 
 
 @app.get("/api/sql-diagnostics")
 async def get_sql_diagnostics() -> SqlDiagnostics:
     try:
-        issues = await inspect_dbos_schema(db)
+        report = await inspect_dbos_schema(db)
     except SQLAlchemyError as e:
         raise HTTPException(status_code=503, detail="database diagnostics unavailable") from e
+    compat = report.compat
     return SqlDiagnostics(
-        ok=not issues,
+        ok=not report.issues,
         issues=[
             SqlDiagnosticIssue(
                 kind=issue.kind,
@@ -173,8 +196,18 @@ async def get_sql_diagnostics() -> SqlDiagnostics:
                 actual_type=issue.actual_type,
                 detail=issue.detail,
             )
-            for issue in issues
+            for issue in report.issues
         ],
+        compat=DbosCompat(
+            dialect=compat.dialect,
+            revision=compat.revision,
+            required_revision=compat.required_revision,
+            compatible=compat.compatible,
+            recommended_argus_version=compat.recommended_argus_version,
+            recommended_dbos_version=compat.recommended_dbos_version,
+            missing_columns=list(compat.missing_columns),
+            message=compat.message,
+        ),
     )
 
 

--- a/packages/server/dbos_argus/sql_diagnostics.py
+++ b/packages/server/dbos_argus/sql_diagnostics.py
@@ -1,27 +1,45 @@
 """Schema diagnostics: load the packaged snapshot, reflect the live DB through
-the adapter, diff them.
+the adapter, diff them, and grade the DB's DBOS schema revision.
 
 The actual machinery is split between `schema_dump` (load the JSON snapshot
 into a `SchemaDump`), the adapter's `reflect_schema()` (per-dialect live
-reflection), and `schema_diff` (a generic dump-vs-dump comparator). This
-module is the wiring the FastAPI endpoint calls.
+reflection), `schema_diff` (a generic dump-vs-dump comparator), and `compat`
+(revision-to-Argus-version mapping). This module is the wiring the FastAPI
+endpoint calls.
 
 The packaged snapshot in `data/dbos_schema.json` is the *full* DBOS schema
 with per-column `argus: true|false` markers. For runtime diagnostics we filter
 to the argus-marked subset before diffing against the live DB; the unmarked
 columns are tracked by the CI watchdog only.
+
+The two halves answer different questions and are both worth reporting: the diff
+says *what* is missing, the compat report says *which Argus version to run
+instead*. The diff also stands alone when the revision can't be read at all.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from .compat import CompatReport, resolve_compat
 from .db.base import ArgusDB
 from .schema_diff import SchemaIssue, diff_schemas
 from .schema_dump import argus_only, load_full_dump
 
-__all__ = ["SchemaIssue", "inspect_dbos_schema"]
+__all__ = ["DbosSchemaReport", "SchemaIssue", "inspect_dbos_schema"]
 
 
-async def inspect_dbos_schema(db: ArgusDB) -> list[SchemaIssue]:
+@dataclass(frozen=True)
+class DbosSchemaReport:
+    issues: list[SchemaIssue]
+    compat: CompatReport
+
+
+async def inspect_dbos_schema(db: ArgusDB) -> DbosSchemaReport:
     expected = argus_only(load_full_dump())
     actual = await db.reflect_schema(schema=expected.schema)
-    return diff_schemas(expected, actual)
+    revision = await db.dbos_schema_revision()
+    return DbosSchemaReport(
+        issues=diff_schemas(expected, actual),
+        compat=resolve_compat(db.dialect, revision),
+    )

--- a/packages/server/tests/integration/test_compat_floor.py
+++ b/packages/server/tests/integration/test_compat_floor.py
@@ -1,0 +1,155 @@
+"""Exact-floor verification for the Postgres compatibility floor.
+
+`tests/test_compat.py` proves the *SQLite* floor exactly by replaying DBOS'
+SQLite migrations in memory. Postgres DDL needs a live server, so the equivalent
+proof lives here and runs on the `postgres` leg of the CI matrix.
+
+Without it an understated Postgres floor passes every other check: the SQLite
+guard is blind to the Postgres number, and the fully-migrated fixture in
+`test_db_adapter.py` satisfies any floor at or below what DBOS currently
+reaches. A user sitting at the understated revision would then be told they're
+compatible and crash on the missing column — precisely the failure `compat.py`
+exists to prevent, on the dialect most deployments run.
+
+The probe migrates a throwaway schema with DBOS' own migration SQL, so it tracks
+upstream automatically: no column lists or ordinals are duplicated here.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from dbos_argus.compat import required_revision
+from dbos_argus.db.base import ArgusDB
+from dbos_argus.schema_diff import diff_schemas
+from dbos_argus.schema_dump import argus_only, dump_live_schema, load_full_dump
+from sqlalchemy import create_engine, text
+
+from .conftest import _to_sync_url
+
+# Kept out of the way of the fixture's own `dbos` schema so the two can coexist
+# inside one test session.
+PROBE_SCHEMA = "dbos_compat_probe"
+
+
+class UnverifiedCompatFloorWarning(UserWarning):
+    """Raised when the Postgres floor check is skipped for lack of a server.
+
+    A bare `pytest.skip` renders as an unexplained `s` under `-q`, which reads
+    like "nothing to see here" — the one impression this skip must not leave,
+    since the unchecked field is the one most deployments depend on.
+    """
+
+
+def _migrate_probe_schema(sync_url: str, upto: int) -> None:
+    """(Re)create `PROBE_SCHEMA` and apply DBOS' first `upto` Postgres migrations.
+
+    Mirrors `dbos._migration.run_dbos_migrations`' two special cases: online
+    migrations need autocommit (they contain CONCURRENTLY index DDL), and
+    migration 10 back-fills a primary key that current DBOS already creates in
+    migration 1.
+    """
+    from dbos._migration import _ONLINE_MIGRATIONS, get_dbos_migrations
+
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{PROBE_SCHEMA}" CASCADE'))
+            conn.execute(text(f'CREATE SCHEMA "{PROBE_SCHEMA}"'))
+
+        migrations = get_dbos_migrations(PROBE_SCHEMA, use_listen_notify=False)
+        for i, sql in enumerate(migrations[:upto], 1):
+            if i in _ONLINE_MIGRATIONS:
+                with engine.connect() as raw_conn:
+                    conn = raw_conn.execution_options(isolation_level="AUTOCOMMIT")
+                    conn.execute(text(sql))
+                continue
+            if i == 10:
+                with engine.begin() as conn:
+                    already_has_pk = conn.execute(
+                        text(
+                            "SELECT 1 FROM information_schema.table_constraints "
+                            "WHERE table_schema = :schema AND table_name = 'notifications' "
+                            "AND constraint_type = 'PRIMARY KEY'"
+                        ),
+                        {"schema": PROBE_SCHEMA},
+                    ).scalar()
+                    if not already_has_pk:
+                        conn.execute(text(sql))
+                continue
+            with engine.begin() as conn:
+                conn.execute(text(sql))
+    finally:
+        engine.dispose()
+
+
+def _drop_probe_schema(sync_url: str) -> None:
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{PROBE_SCHEMA}" CASCADE'))
+    finally:
+        engine.dispose()
+
+
+async def _argus_columns_missing_at(db: ArgusDB, sync_url: str, revision: int) -> list[str]:
+    """Argus-tracked columns absent from a schema migrated to `revision`.
+
+    Runs the production comparator (`diff_schemas`) against the packaged
+    snapshot, so this asserts on exactly what `/api/sql-diagnostics` would say.
+    """
+    _migrate_probe_schema(sync_url, revision)
+    async with db.engine.connect() as conn:
+        reflected = await dump_live_schema(conn, schema=PROBE_SCHEMA)
+    issues = diff_schemas(argus_only(load_full_dump()), reflected)
+    return [f"{i.table_name}.{i.column_name or '*'}" for i in issues]
+
+
+async def test_declared_postgres_floor_is_exact(
+    populated_db: tuple[ArgusDB, dict[str, object]],
+    db_url: str,
+) -> None:
+    """The declared Postgres floor must be the *lowest* revision providing every
+    argus-tracked column: sufficient at the floor, insufficient one below.
+
+    Flipping a column to `argus: true` without appending a `CompatStep` fails the
+    first assert; overstating the floor fails the second. See CONTRIBUTING.md →
+    "Bumping the compatibility floor".
+    """
+    db, _ = populated_db
+    if db.dialect != "postgres":
+        warnings.warn(
+            "Postgres compatibility floor NOT verified in this run "
+            f"(compat.py declares {required_revision('postgres')}). This check needs a live "
+            "server; the SQLite floor was verified in tests/test_compat.py. An understated "
+            "Postgres floor passes every other test and would tell users their database is "
+            "compatible when it is not. CI always runs this on the postgres matrix leg. To "
+            "run it locally:\n"
+            "  docker compose up -d postgres\n"
+            "  ARGUS_TEST_DATABASE_URL='postgresql+asyncpg://argus:argus@localhost:5432/argus'"
+            " uv run pytest packages/server",
+            UnverifiedCompatFloorWarning,
+            # stacklevel=1 keeps the attribution on this file. Anything higher
+            # walks into asyncio's event-loop internals, since the caller of an
+            # async test is the loop, not the test module.
+            stacklevel=1,
+        )
+        pytest.skip("Postgres-only: needs ARGUS_TEST_DATABASE_URL (see warnings summary)")
+
+    sync_url = _to_sync_url(db_url)
+    floor = required_revision("postgres")
+    try:
+        missing_at_floor = await _argus_columns_missing_at(db, sync_url, floor)
+        assert missing_at_floor == [], (
+            f"Postgres revision {floor} does not provide argus-tracked columns "
+            f"{missing_at_floor} — append a CompatStep in compat.py"
+        )
+
+        missing_below = await _argus_columns_missing_at(db, sync_url, floor - 1)
+        assert missing_below, (
+            f"Postgres revision {floor - 1} already provides every argus-tracked "
+            f"column, so the declared floor {floor} is higher than necessary"
+        )
+    finally:
+        _drop_probe_schema(sync_url)

--- a/packages/server/tests/integration/test_db_adapter.py
+++ b/packages/server/tests/integration/test_db_adapter.py
@@ -8,6 +8,7 @@ fixture — there is no per-dialect branching here.
 
 from __future__ import annotations
 
+from dbos_argus.compat import required_revision
 from dbos_argus.db.base import ArgusDB
 from dbos_argus.db.rows import NotificationFilters, WorkflowFilters
 from dbos_argus.sql_diagnostics import inspect_dbos_schema
@@ -47,8 +48,28 @@ async def test_live_schema_matches_pinned_snapshot(populated_db: DB) -> None:
     not the other, the matrix leg pointing at the affected backend will
     fail here — surfacing drift the PG-only watchdog can't see."""
     db, _ = populated_db
-    issues = await inspect_dbos_schema(db)
-    assert issues == [], "schema drift: " + "; ".join(i.detail for i in issues)
+    report = await inspect_dbos_schema(db)
+    assert report.issues == [], "schema drift: " + "; ".join(i.detail for i in report.issues)
+
+
+async def test_fully_migrated_db_meets_declared_revision_floor(populated_db: DB) -> None:
+    """The fixture is migrated by DBOS' own runner, so its `dbos_migrations`
+    version is ground truth for what the current DBOS release reaches. Guards
+    `compat.COMPAT_STEPS` against a floor that no real database can satisfy —
+    e.g. a typo'd bump, or one made against the wrong dialect's numbering."""
+    db, _ = populated_db
+    revision = await db.dbos_schema_revision()
+    floor = required_revision(db.dialect)
+    assert revision is not None, "bootstrap should have created dbos_migrations"
+    assert revision >= floor, (
+        f"declared floor {floor} for {db.dialect} exceeds what DBOS actually "
+        f"migrates to ({revision}) — COMPAT_STEPS is unsatisfiable"
+    )
+
+    report = await inspect_dbos_schema(db)
+    assert report.compat.compatible
+    assert report.compat.revision == revision
+    assert report.compat.recommended_argus_version is None
 
 
 async def test_list_workflows_grouped_returns_full_tree(populated_db: DB) -> None:

--- a/packages/server/tests/test_compat.py
+++ b/packages/server/tests/test_compat.py
@@ -1,0 +1,216 @@
+"""Tests for the DBOS schema-revision compatibility ladder.
+
+Three layers:
+  - Ladder invariants (`COMPAT_STEPS` is well-formed).
+  - `resolve_compat` behaviour across both dialects and the unknown-revision case.
+  - A drift guard that replays DBOS' own SQLite migrations to derive the floor
+    empirically and compare it against what `compat.py` declares. Skipped when
+    `dbos` isn't importable so the suite still runs against a bare install.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from dbos_argus.compat import COMPAT_STEPS, Dialect, required_revision, resolve_compat
+from dbos_argus.schema_dump import argus_only, load_full_dump
+
+DIALECTS: tuple[Dialect, ...] = ("postgres", "sqlite")
+
+
+# --- ladder invariants -------------------------------------------------------
+
+
+def test_steps_are_ascending_per_dialect() -> None:
+    for dialect in DIALECTS:
+        revisions = [s.revision_for(dialect) for s in COMPAT_STEPS]
+        assert revisions == sorted(revisions), f"{dialect} revisions must ascend"
+        assert len(set(revisions)) == len(revisions), f"{dialect} revisions must be distinct"
+
+
+def test_only_the_final_step_has_no_pin() -> None:
+    # A None `max_argus_version` means "current build" — only meaningful on the
+    # last step, since every earlier one must name a release to fall back to.
+    assert COMPAT_STEPS[-1].max_argus_version is None
+    assert all(s.max_argus_version is not None for s in COMPAT_STEPS[:-1])
+
+
+def test_required_revision_tracks_the_final_step() -> None:
+    for dialect in DIALECTS:
+        assert required_revision(dialect) == COMPAT_STEPS[-1].revision_for(dialect)
+
+
+def test_first_step_is_reachable_by_any_database() -> None:
+    # The base step must be satisfied by revision 0 so `resolve_compat` always
+    # has a step to fall back to.
+    for dialect in DIALECTS:
+        assert COMPAT_STEPS[0].revision_for(dialect) == 0
+
+
+# --- resolve_compat ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_current_revision_is_compatible(dialect: Dialect) -> None:
+    report = resolve_compat(dialect, required_revision(dialect))
+    assert report.compatible
+    assert report.message is None
+    assert report.recommended_argus_version is None
+    assert report.missing_columns == ()
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_future_revision_is_compatible(dialect: Dialect) -> None:
+    # A DBOS newer than this build only adds columns we don't read.
+    report = resolve_compat(dialect, required_revision(dialect) + 50)
+    assert report.compatible
+    assert report.recommended_argus_version is None
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_unknown_revision_makes_no_claim(dialect: Dialect) -> None:
+    # No dbos_migrations table: fresh DB, or legacy Alembic-managed. The column
+    # diff is the authority, so compat must not cry wolf.
+    report = resolve_compat(dialect, None)
+    assert report.compatible
+    assert report.revision is None
+    assert report.message is None
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_one_below_floor_recommends_the_previous_release(dialect: Dialect) -> None:
+    floor = required_revision(dialect)
+    report = resolve_compat(dialect, floor - 1)
+    assert not report.compatible
+    assert report.revision == floor - 1
+    assert report.required_revision == floor
+    assert report.recommended_argus_version == COMPAT_STEPS[-2].max_argus_version
+    # Only the final step is unmet, so only its columns are reported missing.
+    assert report.missing_columns == COMPAT_STEPS[-1].requires
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_ancient_revision_accumulates_every_unmet_step(dialect: Dialect) -> None:
+    report = resolve_compat(dialect, 1)
+    assert not report.compatible
+    assert report.recommended_argus_version == COMPAT_STEPS[0].max_argus_version
+    # Union of every step above the base, in ladder order.
+    expected = tuple(c for step in COMPAT_STEPS[1:] for c in step.requires)
+    assert report.missing_columns == expected
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_upgrade_advice_clears_every_unmet_step(dialect: Dialect) -> None:
+    # Pointing at the *next* step's DBOS version would leave the user still
+    # broken; the advice must name the version that satisfies Argus outright.
+    report = resolve_compat(dialect, 1)
+    assert report.recommended_dbos_version == COMPAT_STEPS[-1].dbos_version
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_message_is_actionable(dialect: Dialect) -> None:
+    floor = required_revision(dialect)
+    report = resolve_compat(dialect, floor - 1)
+    assert report.message is not None
+    assert str(floor) in report.message
+    assert str(floor - 1) in report.message
+    assert report.recommended_argus_version is not None
+    # The pin is the whole point of the message.
+    assert f"dbos-argus=={report.recommended_argus_version}" in report.message
+    for column in report.missing_columns:
+        assert column in report.message
+
+
+def test_dialects_have_distinct_floors() -> None:
+    # Postgres and SQLite migration lists diverge; a single shared number would
+    # silently mis-grade one of the backends.
+    assert required_revision("postgres") != required_revision("sqlite")
+
+
+# --- drift guard against DBOS' real migrations -------------------------------
+
+
+def _sqlite_columns_after(n: int) -> dict[str, set[str]]:
+    """Apply DBOS' first `n` SQLite migrations to an in-memory DB and return
+    `{table: {column, ...}}`. Uses DBOS' own migration SQL, so the result is
+    exactly what a real DBOS app at revision `n` would have."""
+    from dbos._migration import sqlite_migrations
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        for migration in sqlite_migrations[:n]:
+            for statement in (s.strip() for s in migration.split(";") if s.strip()):
+                conn.execute(statement)
+        tables = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        ]
+        return {t: {r[1] for r in conn.execute(f'PRAGMA table_info("{t}")')} for t in tables}
+    finally:
+        conn.close()
+
+
+def _missing_argus_columns(present: dict[str, set[str]]) -> set[str]:
+    """`table.column` entries the snapshot marks argus-tracked but `present` lacks."""
+    expected = argus_only(load_full_dump())
+    return {
+        f"{table.name}.{column.name}"
+        for table in expected.tables
+        for column in table.columns
+        if column.name not in present.get(table.name, set())
+    }
+
+
+def test_readme_table_matches_the_ladder() -> None:
+    """The README's compatibility table is the artifact users actually read, and
+    nothing else keeps it honest. Assert every step's numbers and pin appear in
+    it, so a `COMPAT_STEPS` edit can't silently leave the docs behind."""
+    readme = Path(__file__).resolve().parents[3] / "README.md"
+    section = readme.read_text().split("## Which Argus version do I need?", 1)
+    assert len(section) == 2, "README lost the compatibility section"
+    table = section[1].split("\n## ", 1)[0]
+
+    for step in COMPAT_STEPS:
+        if step.max_argus_version is None:
+            # Current build: the table says "latest" rather than a pin.
+            assert f"≥ {step.postgres}" in table
+            assert f"≥ {step.sqlite}" in table
+            continue
+        assert step.max_argus_version in table, (
+            f"README table is missing the `{step.max_argus_version}` row"
+        )
+        # Each non-final step bounds a range whose upper edge is the next step's
+        # revision minus one; the lower edge is the step's own revision.
+        if step.postgres:
+            assert str(step.postgres) in table
+        if step.sqlite:
+            assert str(step.sqlite) in table
+
+
+def test_declared_sqlite_floor_is_exact() -> None:
+    """The declared SQLite floor must be the *lowest* revision that satisfies
+    every argus-tracked column: sufficient at the floor, and insufficient one
+    below it.
+
+    This is the guard the maintenance note in `compat.py` relies on. Marking a
+    new column `argus: true` without appending a `CompatStep` fails the first
+    assert; bumping the floor higher than necessary fails the second.
+    """
+    pytest.importorskip("dbos", reason="drift guard needs DBOS' migration SQL")
+    floor = required_revision("sqlite")
+
+    missing_at_floor = _missing_argus_columns(_sqlite_columns_after(floor))
+    assert missing_at_floor == set(), (
+        f"SQLite revision {floor} does not provide argus-tracked columns "
+        f"{sorted(missing_at_floor)} — append a CompatStep in compat.py"
+    )
+
+    missing_below = _missing_argus_columns(_sqlite_columns_after(floor - 1))
+    assert missing_below, (
+        f"SQLite revision {floor - 1} already provides every argus-tracked "
+        f"column, so the declared floor {floor} is higher than necessary"
+    )

--- a/packages/server/tests/test_sql_diagnostics.py
+++ b/packages/server/tests/test_sql_diagnostics.py
@@ -1,4 +1,5 @@
 from dbos_argus import main
+from dbos_argus.compat import COMPAT_STEPS, Dialect, required_revision, resolve_compat
 from dbos_argus.main import app
 from dbos_argus.schema_diff import SchemaIssue, diff_schemas
 from dbos_argus.schema_dump import (
@@ -8,6 +9,7 @@ from dbos_argus.schema_dump import (
     argus_only,
     load_full_dump,
 )
+from dbos_argus.sql_diagnostics import DbosSchemaReport
 from fastapi.testclient import TestClient
 
 
@@ -119,20 +121,31 @@ def test_version_endpoint_includes_tested_dbos_version() -> None:
     assert "tested_dbos_version" in body
     # Snapshot ships with a real version string; reject "unknown" fallback in tests.
     assert body["tested_dbos_version"] not in ("", "unknown")
+    # Reported without touching the DB, so it's always a positive integer.
+    assert int(body["required_dbos_schema_revision"]) > 0
+
+
+def _report(
+    issues: list[SchemaIssue],
+    *,
+    revision: int | None,
+    dialect: Dialect = "postgres",
+) -> DbosSchemaReport:
+    return DbosSchemaReport(issues=issues, compat=resolve_compat(dialect, revision))
 
 
 def test_sql_diagnostics_endpoint_returns_schema_issues(monkeypatch) -> None:
-    async def fake_inspect_dbos_schema(_db: object) -> list[SchemaIssue]:
-        return [
-            SchemaIssue(
-                kind="missing_table",
-                table_name="workflow_schedules",
-                column_name=None,
-                expected_type=None,
-                actual_type=None,
-                detail="Missing required table dbos.workflow_schedules.",
-            )
-        ]
+    issue = SchemaIssue(
+        kind="missing_table",
+        table_name="workflow_schedules",
+        column_name=None,
+        expected_type=None,
+        actual_type=None,
+        detail="Missing required table dbos.workflow_schedules.",
+    )
+
+    async def fake_inspect_dbos_schema(_db: object) -> DbosSchemaReport:
+        return _report([issue], revision=required_revision("postgres"))
 
     monkeypatch.setattr(main, "inspect_dbos_schema", fake_inspect_dbos_schema)
 
@@ -140,16 +153,56 @@ def test_sql_diagnostics_endpoint_returns_schema_issues(monkeypatch) -> None:
         response = client.get("/api/sql-diagnostics")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "ok": False,
-        "issues": [
-            {
-                "kind": "missing_table",
-                "table_name": "workflow_schedules",
-                "column_name": None,
-                "expected_type": None,
-                "actual_type": None,
-                "detail": "Missing required table dbos.workflow_schedules.",
-            }
-        ],
-    }
+    body = response.json()
+    assert body["ok"] is False
+    assert body["issues"] == [
+        {
+            "kind": "missing_table",
+            "table_name": "workflow_schedules",
+            "column_name": None,
+            "expected_type": None,
+            "actual_type": None,
+            "detail": "Missing required table dbos.workflow_schedules.",
+        }
+    ]
+    # Schema issues and revision compatibility are graded independently: a
+    # dropped table on an otherwise-current DBOS is not a version problem.
+    assert body["compat"]["compatible"] is True
+    assert body["compat"]["recommended_argus_version"] is None
+
+
+def test_sql_diagnostics_endpoint_recommends_a_pin_for_an_old_revision(monkeypatch) -> None:
+    floor = required_revision("postgres")
+
+    async def fake_inspect_dbos_schema(_db: object) -> DbosSchemaReport:
+        return _report([], revision=floor - 1)
+
+    monkeypatch.setattr(main, "inspect_dbos_schema", fake_inspect_dbos_schema)
+
+    with TestClient(app) as client:
+        response = client.get("/api/sql-diagnostics")
+
+    assert response.status_code == 200
+    compat = response.json()["compat"]
+    assert compat["compatible"] is False
+    assert compat["revision"] == floor - 1
+    assert compat["required_revision"] == floor
+    assert compat["recommended_argus_version"] == COMPAT_STEPS[-2].max_argus_version
+    assert compat["missing_columns"] == list(COMPAT_STEPS[-1].requires)
+    assert "dbos-argus==" in compat["message"]
+
+
+def test_sql_diagnostics_endpoint_makes_no_claim_without_a_revision(monkeypatch) -> None:
+    # Legacy Alembic-managed DB: no dbos_migrations table to read.
+    async def fake_inspect_dbos_schema(_db: object) -> DbosSchemaReport:
+        return _report([], revision=None)
+
+    monkeypatch.setattr(main, "inspect_dbos_schema", fake_inspect_dbos_schema)
+
+    with TestClient(app) as client:
+        response = client.get("/api/sql-diagnostics")
+
+    compat = response.json()["compat"]
+    assert compat["revision"] is None
+    assert compat["compatible"] is True
+    assert compat["message"] is None

--- a/scripts/dbos_schema_compare.py
+++ b/scripts/dbos_schema_compare.py
@@ -216,7 +216,12 @@ def _format_report(
         lines.append("")
         lines.append(
             "DBOS shipped these — Argus doesn't currently read them. "
-            "Adopt one by flipping `argus: true` in the snapshot and adding queries."
+            "Adopt one by flipping `argus: true` in the snapshot and adding queries. "
+            "Adopting a column also raises the minimum DBOS schema revision Argus "
+            "can read, so update `packages/server/dbos_argus/compat.py` in the same "
+            'change — see CONTRIBUTING.md → "Bumping the compatibility floor". '
+            "CI enforces this: the floor tests fail if the ladder and the adopted "
+            "columns disagree."
         )
         lines.append("")
         if deltas.added_tables:


### PR DESCRIPTION
## Problem

Pointing Argus at a database migrated by an older DBOS release fails with an opaque `column does not exist` on the workflow list or detail page. Nothing tells the user what went wrong or what to do about it.

## Approach

Argus now reads DBOS Transact's own schema revision counter (`dbos.dbos_migrations.version`) and maps it to the newest Argus release that works against that database.

The revision counter is the key rather than the `dbos` package version, because:

- The package version isn't in the database at all. `dbos.application_versions` holds the *host application's* version, not DBOS'.
- The package version can lie: upgrading `dbos` without restarting the app that runs the migrations leaves the database behind what the library advertises.
- A missing column is a migration fact, so the migration counter answers the question directly instead of by proxy.

Floors are tracked **per dialect** because DBOS' Postgres and SQLite migration lists diverge (SQLite has no counterpart for a handful of Postgres-only migrations). The current requirement is revision **41 on Postgres, 36 on SQLite**.

| `dbos_migrations.version` (PG / SQLite) | Use Argus | Because it reads |
|---|---|---|
| ≥ 41 / ≥ 36 | latest | — |
| 36–40 / 33–35 | `0.0.28` | `workflow_status.attributes`, `.schedule_name` |
| < 36 / < 33 | `0.0.27` | `workflow_status.completed_at` |

A database with no `dbos_migrations` table (fresh, or legacy Alembic-managed) is deliberately **not** graded — the existing column diff stays the authority there.

## Surfaces

- Console connection panel: revision reads `34 / 36 needed`, with a callout giving the `pip install` line, the DBOS version to upgrade to, and the exact missing columns.
- `GET /api/sql-diagnostics` gains a `compat` object.
- `GET /version` reports `required_dbos_schema_revision`; `dbos-argus --version` prints both dialects' floors. Neither touches the database.

## CI guards

The ladder has to stay in sync with what Argus actually reads, so CI enforces it from both directions:

- **SQLite floor** — proven exactly by replaying DBOS' SQLite migrations in memory (`tests/test_compat.py`).
- **Postgres floor** — proven by migrating a throwaway schema with DBOS' real DDL on the `postgres` matrix leg (`tests/integration/test_compat_floor.py`).

Both assert the declared floor is the *lowest* revision providing every argus-tracked column: adopting a column without bumping the ladder fails, and so does overshooting. Without the Postgres check, an understated Postgres floor passed every other test and would have reported a broken database as compatible — verified by deliberately setting it to 40 and watching the new test name `workflow_status.schedule_name`.

A third test keeps the README table in sync with the ladder, and running the suite with no Postgres server emits an explicit warning that the Postgres floor went unverified rather than a silent skip.

## Verification

- Both matrix legs: 111 passed + 1 skipped (SQLite), 112 passed (Postgres).
- End-to-end against a SQLite database deliberately migrated to revision 34: the console rendered the pin advice, and the compat report and column diff agreed exactly. A fully-migrated database shows nothing.
- Negative controls run for the understated floor, the overstated floor, and a stale README row.

## Note

The `0.0.27` / `0.0.28` boundaries are derived from the CHANGELOG's recorded floors, not from installing those releases against period-correct databases.