### PR TITLE
docs: use an annotated tag in the release steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,4 +109,4 @@ Three GitHub Actions workflows:
 
 ## Releasing
 
-Tag-driven. Bump `CHANGELOG.md` (move `[Unreleased]` → dated `[X.Y.Z]`), commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`. Version comes from `hatch-vcs` reading the tag — nothing to bump in `pyproject.toml` or `__init__.py`. PyPI rejects re-uploading the same version, so each release must bump.
+Tag-driven. Bump `CHANGELOG.md` (move `[Unreleased]` → dated `[X.Y.Z]`), commit, then `git tag -m "vX.Y.Z" vX.Y.Z && git push origin vX.Y.Z`. Use `-m`: with `tag.gpgsign = true` (set globally in the maintainer's git config, not per-repo) tags become signed *annotated* tags and a bare `git tag vX.Y.Z` aborts with `fatal: no tag message?`. The `-m` form is harmless without that config, so prefer it unconditionally. Version comes from `hatch-vcs` reading the tag — nothing to bump in `pyproject.toml` or `__init__.py`. PyPI rejects re-uploading the same version, so each release must bump.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,11 @@ git commit -am "release vX.Y.Z"
 git push
 
 # 3. Tag and push the tag. The pipeline takes it from here.
-git tag vX.Y.Z
+#    `-m` makes this an annotated tag, which a bare `git tag vX.Y.Z` is not.
+#    Required if you have `tag.gpgsign = true` (that config turns tags into
+#    signed annotated tags, and git then aborts with "fatal: no tag message?").
+#    Harmless otherwise, so this form works either way.
+git tag -m "vX.Y.Z" vX.Y.Z
 git push origin vX.Y.Z
 ```
 


### PR DESCRIPTION
Hit while releasing v0.0.32: the documented `git tag vX.Y.Z` aborts with

```
fatal: no tag message?
```

when `tag.gpgsign` is set, because that config makes tags signed *annotated* tags and git then requires a message. Both `CLAUDE.md` and `CONTRIBUTING.md` documented the bare form, so the release procedure was not copy-pasteable for a maintainer with signing configured.

`git tag -m "vX.Y.Z" vX.Y.Z` works either way:

| `tag.gpgsign` | Result |
|---|---|
| `true` | signed annotated tag (what `v0.0.31` and `v0.0.32` are) |
| unset / `false` | plain annotated tag |

Verified both in a scratch repo. Worth noting the bare form produced a **lightweight** tag (`objecttype commit`) when signing was off, so this also stops contributors without signing configured from creating lightweight release tags — every existing release tag is annotated, and this keeps that uniform.

`tag.gpgsign` is set globally in the maintainer's git config rather than per-repo, so the CONTRIBUTING note is phrased conditionally and CLAUDE.md says where the setting lives.

Docs only — no CHANGELOG entry, since nothing user-facing changed.