### PR TITLE
console: canvas redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rounded card that collapses to a single expand button, giving its space back
   to the graph. Dark mode keeps the same structure with hairline rings in
   place of shadows.
+- **Console theme: warm canvas, iris accent.** The shell background warms from
+  cool zinc to a stone-family gray, and the primary accent moves from
+  violet-700 to a muted iris that reads calm rather than royal against it.
+  Both hold in dark mode, and the queued-status purple gains hue separation
+  from the accent as a side effect.
+- Console polish: dashboard throughput bars get a rounded top cap that
+  belongs to the bar rather than its topmost stacked segment, so it shows for
+  every bar regardless of composition or height; the Top queues card fits its
+  column headers and aligns the value columns under them; the sidebar
+  collapse animates at 150ms with easing (was 200ms linear); the collapsed
+  rail renders the database status button like the other nav items; workflow
+  graph collapse buttons paint above the dashed spawn/return edges; the
+  details pane header drops its separator; and the Raw/Decoded toggles get
+  their track background back.
 
 ## [0.0.32] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Tested against DBOS 2.27.0.** See `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility.
 
+### Changed
+- **Console "canvas" redesign.** The console moves from white-on-white panels
+  with gray hairline borders to a soft gray canvas with borderless white
+  surfaces separated by shadow. The header loses its bottom border and
+  separators and gets slightly shorter; the sidebar drops its border and
+  renders the active item as a raised pill; cards, outline buttons, and filter
+  controls swap gray outlines for a subtle shadow ring; secondary text is
+  darker for contrast. In the workflow graph, step nodes are now flat
+  full-width rows (no boxes, no borders, no connecting lines between steps —
+  status dots and order carry the sequence), workflow containers float as
+  shadowed cards on a dotted canvas, and the details pane is a floating
+  rounded card that collapses to a single expand button, giving its space back
+  to the graph. Dark mode keeps the same structure with hairline rings in
+  place of shadows.
+
 ## [0.0.32] - 2026-07-25
 
 > **Tested against DBOS 2.27.0.** Requires DBOS schema revision 41 (Postgres) / 36 (SQLite) — see `required_dbos_schema_revision` in `GET /version`, or the compatibility table in [README.md](./README.md#which-argus-version-do-i-need). Argus tracks the latest DBOS schema and does not aim for backward compatibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ The console's visual theme is split into two files so shadcn presets can be swap
 - **`apps/console/src/theme.css`** — generated. Holds the preset's `:root` and `.dark` blocks: base palette (background/foreground/card/popover/muted/accent/border/input/ring), `--primary`, `--secondary`, `--destructive`, `--chart-1..5`, sidebar tokens, `--radius`, `--font-sans`, `--font-heading`. Header comment records the preset code. **Do not hand-edit.**
 - **`apps/console/src/app.css`** — hand-maintained. Imports `theme.css`, declares Argus-specific tokens that survive preset swaps (`--status-success/running/queued/warning/error`, `--highlight*`, `--font-mono`), registers everything in `@theme inline`, and holds `@layer base`.
 
+The console deliberately diverges from the preset's surface treatment ("canvas" redesign): `app.css` overrides `--background` (soft gray canvas), `--muted-foreground` (darker, for contrast), and points `--sidebar`/`--sidebar-accent` at the canvas/card colors. Containers are borderless white surfaces separated by `--surface-shadow` / `--surface-shadow-lg` (registered as `shadow-surface` / `shadow-surface-lg` utilities); the `ui/card` and outline-button components use them instead of `border`. Cascade gotcha: any light-mode token overridden in `app.css`'s `:root` outranks `theme.css`'s `.dark` block by source order, so its dark value must be restated in `app.css`'s `.dark` block (see `--background`, `--muted-foreground`). Preset swaps still control primary/radius/fonts/dark palette.
+
 To swap to a new preset:
 
 1. Pick a preset at https://ui.shadcn.com/create — the URL ends with `?preset=<code>`.

--- a/apps/console/src/app.css
+++ b/apps/console/src/app.css
@@ -30,6 +30,18 @@
      deeper primary that reads dim against the dark card surface. */
   --workflow-accent: var(--primary);
   --font-heading: "Inter Variable", sans-serif;
+  /* Canvas redesign: the page is a soft gray canvas and containers are
+     borderless white surfaces separated by shadow, not gray outlines. These
+     intentionally override the preset in theme.css and survive preset swaps. */
+  --background: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.44 0.01 285.9);
+  /* Sidebar sits directly on the canvas; the active item is a raised card. */
+  --sidebar: var(--background);
+  --sidebar-accent: var(--card);
+  --surface-shadow: 0 1px 2px oklch(0.145 0 0 / 7%), 0 0 0 1px oklch(0.145 0 0 / 4.5%);
+  --surface-shadow-lg:
+    0 4px 12px oklch(0.145 0 0 / 8%), 0 1px 2px oklch(0.145 0 0 / 6%),
+    0 0 0 1px oklch(0.145 0 0 / 4%);
 }
 
 .dark {
@@ -41,6 +53,15 @@
   --highlight: oklch(0.85 0.18 95);
   --highlight-foreground: oklch(0.2 0.05 80);
   --workflow-accent: oklch(from var(--primary) 0.82 calc(c + 0.06) h);
+  /* Restate the preset's dark values: the :root canvas overrides above come
+     later in the cascade than theme.css's .dark block and would otherwise
+     leak the light canvas into dark mode. */
+  --background: oklch(0.145 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  /* Shadows barely read in dark mode, so the surface treatment leans on the
+     hairline ring plus the lighter card color for separation. */
+  --surface-shadow: 0 1px 2px oklch(0 0 0 / 40%), 0 0 0 1px oklch(1 0 0 / 9%);
+  --surface-shadow-lg: 0 4px 12px oklch(0 0 0 / 45%), 0 0 0 1px oklch(1 0 0 / 10%);
 }
 
 body {
@@ -59,6 +80,8 @@ body {
   --color-highlight: var(--highlight);
   --color-highlight-foreground: var(--highlight-foreground);
   --color-workflow-accent: var(--workflow-accent);
+  --shadow-surface: var(--surface-shadow);
+  --shadow-surface-lg: var(--surface-shadow-lg);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -97,6 +120,13 @@ body {
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+@layer components {
+  /* The active sidebar item reads as a raised white pill on the canvas. */
+  [data-slot="sidebar-menu-button"][data-active="true"] {
+    box-shadow: var(--surface-shadow);
+  }
 }
 
 @layer base {

--- a/apps/console/src/app.css
+++ b/apps/console/src/app.css
@@ -32,12 +32,18 @@
   --font-heading: "Inter Variable", sans-serif;
   /* Canvas redesign: the page is a soft gray canvas and containers are
      borderless white surfaces separated by shadow, not gray outlines. These
-     intentionally override the preset in theme.css and survive preset swaps. */
-  --background: oklch(0.967 0.001 286.375);
+     intentionally override the preset in theme.css and survive preset swaps.
+     Warm stone-family gray rather than the preset's cool zinc so the shell
+     feels softer. Chroma is nudged above Tailwind stone-100 (0.001), which
+     is visually indistinguishable from zinc at this lightness. */
+  --background: oklch(0.967 0.003 75);
   --muted-foreground: oklch(0.44 0.01 285.9);
   /* Sidebar sits directly on the canvas; the active item is a raised card. */
   --sidebar: var(--background);
   --sidebar-accent: var(--card);
+  /* Accent: muted iris instead of the preset's violet-700 — same family
+     with chroma pulled down so it reads calm rather than royal. */
+  --primary: oklch(0.55 0.17 285);
   --surface-shadow: 0 1px 2px oklch(0.145 0 0 / 7%), 0 0 0 1px oklch(0.145 0 0 / 4.5%);
   --surface-shadow-lg:
     0 4px 12px oklch(0.145 0 0 / 8%), 0 1px 2px oklch(0.145 0 0 / 6%),
@@ -58,6 +64,9 @@
      leak the light canvas into dark mode. */
   --background: oklch(0.145 0 0);
   --muted-foreground: oklch(0.708 0 0);
+  /* Iris accent restated for dark: same value as light — it clears white
+     text either way — stated explicitly rather than relying on the leak. */
+  --primary: oklch(0.55 0.17 285);
   /* Shadows barely read in dark mode, so the surface treatment leans on the
      hairline ring plus the lighter card color for separation. */
   --surface-shadow: 0 1px 2px oklch(0 0 0 / 40%), 0 0 0 1px oklch(1 0 0 / 9%);

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -558,7 +558,7 @@
                 <Copy class="h-3.5 w-3.5" />
               {/if}
             </button>
-            <div class="flex items-center gap-0.5">
+            <div class="bg-muted flex items-center gap-0.5 rounded-md p-0.5">
               <button
                 type="button"
                 class="rounded px-2 py-0.5 text-xs font-medium transition
@@ -679,7 +679,7 @@
               <Copy class="h-3.5 w-3.5" />
             {/if}
           </button>
-          <div class="flex items-center gap-0.5">
+          <div class="bg-muted flex items-center gap-0.5 rounded-md p-0.5">
             <button
               type="button"
               class="rounded px-2 py-0.5 text-xs font-medium transition
@@ -771,7 +771,7 @@
                 <Copy class="h-3.5 w-3.5" />
               {/if}
             </button>
-            <div class="flex items-center gap-0.5">
+            <div class="bg-muted flex items-center gap-0.5 rounded-md p-0.5">
               <button
                 type="button"
                 class="rounded px-2 py-0.5 text-xs font-medium transition

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -10,7 +10,6 @@
   import Check from "@lucide/svelte/icons/check";
   import Maximize2 from "@lucide/svelte/icons/maximize-2";
   import PanelRightClose from "@lucide/svelte/icons/panel-right-close";
-  import PanelRightOpen from "@lucide/svelte/icons/panel-right-open";
 
   // Result data is loaded lazily by the parent page (cached for the lifetime
   // of the page) so we never drag potentially-large output blobs through
@@ -47,14 +46,12 @@
     result,
     loading = false,
     events = [],
-    collapsed = false,
     onToggleCollapse,
   }: {
     selection: FlowSelection;
     result: ResultData | null;
     loading?: boolean;
     events?: WorkflowEventEntry[];
-    collapsed?: boolean;
     onToggleCollapse?: () => void;
   } = $props();
 
@@ -402,7 +399,7 @@
   }
 </script>
 
-<aside class="bg-background flex h-full min-h-0 w-full flex-col overflow-hidden">
+<aside class="bg-card flex h-full min-h-0 w-full flex-col overflow-hidden">
   <div class="border-border flex min-h-10 items-center gap-2 border-b px-4 py-2.5">
     <span class="text-muted-foreground truncate text-xs font-medium tracking-wide uppercase">
       {heading?.resultLabel ?? "Result"}
@@ -413,21 +410,15 @@
         size="icon-sm"
         class="ml-auto"
         onclick={onToggleCollapse}
-        title={collapsed ? "Expand" : "Collapse"}
-        aria-label={collapsed ? "Expand details pane" : "Collapse details pane"}
+        title="Collapse"
+        aria-label="Collapse details pane"
       >
-        {#if collapsed}
-          <PanelRightOpen />
-        {:else}
-          <PanelRightClose />
-        {/if}
+        <PanelRightClose />
       </Button>
     {/if}
   </div>
 
-  {#if collapsed}
-    <!-- Body hidden — only the eyebrow header is visible, acting as a tab. -->
-  {:else if !selection || !heading}
+  {#if !selection || !heading}
     <div class="text-muted-foreground flex flex-1 items-center justify-center p-6 text-sm">
       Select a workflow or step to see its result.
     </div>
@@ -477,7 +468,7 @@
         </div>
         <JsonView
           text={attributesText}
-          class="border-border bg-muted/40 max-h-56 overflow-auto rounded-lg border p-3 font-mono text-xs whitespace-pre-wrap break-words"
+          class="bg-muted/40 max-h-56 overflow-auto rounded-lg p-3 font-mono text-xs whitespace-pre-wrap break-words"
         />
       </div>
     {/if}
@@ -720,7 +711,7 @@
         {:else}
           <JsonView
             text={displayedText}
-            class="border-border bg-muted/40 min-h-0 flex-1 overflow-auto rounded-lg border p-4 font-mono text-xs whitespace-pre-wrap break-words"
+            class="bg-muted/40 min-h-0 flex-1 overflow-auto rounded-lg p-4 font-mono text-xs whitespace-pre-wrap break-words"
           />
         {/if}
       </div>
@@ -810,7 +801,7 @@
         </div>
         <JsonView
           text={eventDisplay(openedEvent.value, openedEvent.value_decoded)}
-          class="border-border bg-muted/40 max-h-48 overflow-auto rounded-lg border p-3 font-mono text-xs whitespace-pre-wrap break-words"
+          class="bg-muted/40 max-h-48 overflow-auto rounded-lg p-3 font-mono text-xs whitespace-pre-wrap break-words"
         />
       </div>
       {#if openedEvent.history.length > 0}
@@ -831,7 +822,7 @@
                 </div>
                 <JsonView
                   text={eventDisplay(h.value, h.value_decoded)}
-                  class="border-border bg-muted/40 max-h-48 overflow-auto rounded-lg border p-3 font-mono text-xs whitespace-pre-wrap break-words"
+                  class="bg-muted/40 max-h-48 overflow-auto rounded-lg p-3 font-mono text-xs whitespace-pre-wrap break-words"
                 />
               </li>
             {/each}

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -400,7 +400,7 @@
 </script>
 
 <aside class="bg-card flex h-full min-h-0 w-full flex-col overflow-hidden">
-  <div class="border-border flex min-h-10 items-center gap-2 border-b px-4 py-2.5">
+  <div class="flex min-h-10 items-center gap-2 px-4">
     <span class="text-muted-foreground truncate text-xs font-medium tracking-wide uppercase">
       {heading?.resultLabel ?? "Result"}
     </span>

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -509,7 +509,7 @@
                 </div>
                 <span
                   aria-hidden="true"
-                  class="text-muted-foreground group-hover:text-foreground group-hover:bg-background group-hover:border-border border-transparent absolute top-2 right-1 flex h-7 w-7 items-center justify-center rounded-md border transition-colors"
+                  class="text-muted-foreground group-hover:text-foreground group-hover:bg-card group-hover:border-border border-transparent absolute top-2 right-1 flex h-7 w-7 items-center justify-center rounded-md border transition-colors"
                 >
                   <Maximize2 class="h-3.5 w-3.5" />
                 </span>
@@ -558,12 +558,12 @@
                 <Copy class="h-3.5 w-3.5" />
               {/if}
             </button>
-            <div class="bg-muted flex items-center rounded-md p-0.5">
+            <div class="flex items-center gap-0.5">
               <button
                 type="button"
                 class="rounded px-2 py-0.5 text-xs font-medium transition
                   {effectiveMode === 'raw'
-                    ? 'bg-background text-foreground shadow-xs'
+                    ? 'bg-card text-foreground shadow-surface'
                     : 'text-muted-foreground hover:text-foreground'}"
                 onclick={() => (preferredMode = "raw")}
               >
@@ -574,7 +574,7 @@
                 disabled={payload.decoded === null}
                 class="rounded px-2 py-0.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-40
                   {effectiveMode === 'decoded'
-                    ? 'bg-background text-foreground shadow-xs'
+                    ? 'bg-card text-foreground shadow-surface'
                     : 'text-muted-foreground enabled:hover:text-foreground'}"
                 onclick={() => (preferredMode = "decoded")}
                 title={payload.decoded === null
@@ -618,7 +618,7 @@
             {/if}
             <span
               aria-hidden="true"
-              class="bg-background/80 text-muted-foreground group-hover:text-foreground group-hover:bg-muted group-hover:border-workflow-accent/60 border-border/60 hover:bg-foreground/10 hover:border-workflow-accent absolute top-2 right-2 flex h-7 w-7 items-center justify-center rounded-md border shadow-sm backdrop-blur-sm transition-colors"
+              class="bg-card/80 text-muted-foreground group-hover:text-foreground group-hover:bg-muted group-hover:border-workflow-accent/60 border-border/60 hover:bg-foreground/10 hover:border-workflow-accent absolute top-2 right-2 flex h-7 w-7 items-center justify-center rounded-md border shadow-sm backdrop-blur-sm transition-colors"
             >
               <Maximize2 class="h-3.5 w-3.5" />
             </span>
@@ -679,12 +679,12 @@
               <Copy class="h-3.5 w-3.5" />
             {/if}
           </button>
-          <div class="bg-muted flex items-center rounded-md p-0.5">
+          <div class="flex items-center gap-0.5">
             <button
               type="button"
               class="rounded px-2 py-0.5 text-xs font-medium transition
                 {effectiveMode === 'raw'
-                  ? 'bg-background text-foreground shadow-xs'
+                  ? 'bg-card text-foreground shadow-surface'
                   : 'text-muted-foreground hover:text-foreground'}"
               onclick={() => (preferredMode = "raw")}
             >
@@ -695,7 +695,7 @@
               disabled={payload.decoded === null}
               class="rounded px-2 py-0.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-40
                 {effectiveMode === 'decoded'
-                  ? 'bg-background text-foreground shadow-xs'
+                  ? 'bg-card text-foreground shadow-surface'
                   : 'text-muted-foreground enabled:hover:text-foreground'}"
               onclick={() => (preferredMode = "decoded")}
             >
@@ -771,12 +771,12 @@
                 <Copy class="h-3.5 w-3.5" />
               {/if}
             </button>
-            <div class="bg-muted flex items-center rounded-md p-0.5">
+            <div class="flex items-center gap-0.5">
               <button
                 type="button"
                 class="rounded px-2 py-0.5 text-xs font-medium transition
                   {effectiveEventMode === 'raw'
-                    ? 'bg-background text-foreground shadow-xs'
+                    ? 'bg-card text-foreground shadow-surface'
                     : 'text-muted-foreground hover:text-foreground'}"
                 onclick={() => (eventPreferredMode = "raw")}
               >
@@ -787,7 +787,7 @@
                 disabled={!eventAnyDecoded}
                 class="rounded px-2 py-0.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-40
                   {effectiveEventMode === 'decoded'
-                    ? 'bg-background text-foreground shadow-xs'
+                    ? 'bg-card text-foreground shadow-surface'
                     : 'text-muted-foreground enabled:hover:text-foreground'}"
                 onclick={() => (eventPreferredMode = "decoded")}
                 title={eventAnyDecoded

--- a/apps/console/src/lib/components/StepNode.svelte
+++ b/apps/console/src/lib/components/StepNode.svelte
@@ -122,15 +122,15 @@
   const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 </script>
 
+<!-- Flat full-bleed row: no border, no rounding, no connecting edges — the
+     status dot and vertical order carry the sequence; selection is a primary
+     tint + inset bar. -->
 <div
-  class="flex h-full w-full cursor-pointer items-center gap-2 rounded-md border px-3 py-1
+  class="flex h-full w-full cursor-pointer items-center gap-2 px-3 py-1
     {selected
-      ? 'border-primary bg-primary/5'
-      : 'border-border hover:bg-muted/40'}"
+      ? 'bg-primary/8 shadow-[inset_2px_0_0_var(--color-primary)]'
+      : 'hover:bg-muted/60'}"
 >
-  {#if !data.isFirst}
-    <Handle type="target" position={Position.Top} isConnectable={false} />
-  {/if}
   {#if data.eventDirection}
     <Zap
       class="fill-status-warning text-status-warning dark:fill-highlight dark:text-highlight h-3 w-3 flex-none"
@@ -220,9 +220,6 @@
         <span>{formatDuration(displayDurationMs)}</span>
       {/if}
     </span>
-  {/if}
-  {#if !data.isLast}
-    <Handle type="source" position={Position.Bottom} isConnectable={false} />
   {/if}
   {#if data.kind === "child"}
     <Handle id="spawn" type="source" position={Position.Right} isConnectable={false} />

--- a/apps/console/src/lib/components/WorkflowContainerNode.svelte
+++ b/apps/console/src/lib/components/WorkflowContainerNode.svelte
@@ -21,12 +21,12 @@
 </script>
 
 <div
-  class="bg-card relative flex h-full w-full cursor-pointer flex-col rounded-lg border
+  class="bg-card shadow-surface-lg relative flex h-full w-full cursor-pointer flex-col rounded-lg
     {selected
-      ? 'border-primary'
+      ? 'ring-2 ring-primary'
       : data.isCurrent
-        ? 'border-primary/50'
-        : 'border-foreground/15'}"
+        ? 'ring-primary/50 ring-1'
+        : ''}"
 >
   <Handle
     id="spawn"
@@ -61,7 +61,7 @@
       type="button"
       onclick={handleToggle}
       onmousedown={(e) => e.stopPropagation()}
-      class="border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted absolute -left-3 top-1/2 z-10 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full border shadow-sm"
+      class="bg-card shadow-surface text-muted-foreground hover:text-foreground hover:bg-muted absolute -left-3 top-1/2 z-10 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full"
       aria-label="Collapse steps"
       title="Collapse"
     >
@@ -71,7 +71,7 @@
       type="button"
       onclick={handleToggle}
       onmousedown={(e) => e.stopPropagation()}
-      class="border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted absolute -right-3 top-1/2 z-10 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full border shadow-sm"
+      class="bg-card shadow-surface text-muted-foreground hover:text-foreground hover:bg-muted absolute -right-3 top-1/2 z-10 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full"
       aria-label="Collapse steps"
       title="Collapse"
     >

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount, untrack } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import {
+    Background,
     Controls,
     SvelteFlow,
     type ColorMode,
@@ -60,7 +61,9 @@
     onSelect?: (sel: FlowSelection) => void;
   } = $props();
 
-  const STEP_WIDTH = 220;
+  // Step rows span the full container width (no L/R padding), so STEP_WIDTH
+  // is also the container width for any workflow with steps.
+  const STEP_WIDTH = 252;
   const STEP_HEIGHT = 32;
   const ELLIPSIS_HEIGHT = 22;
   const HEAD = 5;
@@ -69,8 +72,8 @@
   // Minimum container size — ELK collapses empty containers to ~0, which hides
   // the workflow header (name + id). Floor the layout output so a workflow
   // with zero steps yet still renders a proper container box.
-  const CONTAINER_MIN_WIDTH = STEP_WIDTH + 32; // step width + L/R padding
-  const CONTAINER_MIN_HEIGHT = 108; // top padding 60 + 1 step (32) + bottom 16
+  const CONTAINER_MIN_WIDTH = STEP_WIDTH;
+  const CONTAINER_MIN_HEIGHT = 100; // top padding 60 + 1 step (32) + bottom 8
 
   const elk = new ELK();
   const nodeTypes: NodeTypes = {
@@ -497,9 +500,9 @@
           layoutOptions: {
             "elk.algorithm": "layered",
             "elk.direction": "DOWN",
-            "elk.padding": "[top=60,left=16,right=16,bottom=16]",
-            "elk.spacing.nodeNode": "12",
-            "elk.layered.spacing.nodeNodeBetweenLayers": "12",
+            "elk.padding": "[top=60,left=0,right=0,bottom=8]",
+            "elk.spacing.nodeNode": "0",
+            "elk.layered.spacing.nodeNodeBetweenLayers": "0",
             "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
             "elk.layered.crossingMinimization.forceNodeModelOrder": "true",
           },
@@ -666,23 +669,9 @@
           selectable: true,
         });
       }
-      let previousStepId: string | null = null;
-      for (const it of items) {
-        if (it.kind !== "step") continue;
-        const stepId = itemId(c.id!, it);
-        if (!previousStepId) {
-          previousStepId = stepId;
-          continue;
-        }
-        nextEdges.push({
-          id: `seq:${c.id}:${previousStepId}->${stepId}`,
-          source: previousStepId,
-          target: stepId,
-          type: "straight",
-          style: "stroke: var(--color-border); stroke-width: 1px;",
-        });
-        previousStepId = stepId;
-      }
+      // No rendered edges between consecutive steps — the vertical order and
+      // status dots carry the sequence. ELK still gets sequence edges (stage 1
+      // above) so the layout keeps the top→bottom ordering.
     }
 
     // Spawn edges connect step→child container directly via xyflow handles
@@ -806,6 +795,7 @@
     onnodeclick={handleNodeClick}
     onpaneclick={handlePaneClick}
   >
+    <Background gap={18} patternColor="var(--color-border)" />
     <Controls showLock={false} />
   </SvelteFlow>
 </div>

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -778,7 +778,10 @@
   });
 </script>
 
-<div class="bg-background relative h-full min-h-0 w-full overflow-hidden">
+<!-- `isolate` keeps the edge-fade overlays' large z-indexes contained in
+     this container so page-level popovers (nav tooltips, menus, portaled at
+     z-50) still paint above them. -->
+<div class="bg-background relative isolate h-full min-h-0 w-full overflow-hidden">
   <!-- Elevation is disabled because selecting a node otherwise raises it
        (and, via subflow children, every edge touching it) to z 1000+,
        painting spawn/return edges over other containers' step and

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -778,7 +778,7 @@
   });
 </script>
 
-<div class="bg-background h-full min-h-0 w-full overflow-hidden">
+<div class="bg-background relative h-full min-h-0 w-full overflow-hidden">
   <SvelteFlow
     bind:nodes
     bind:edges
@@ -798,6 +798,19 @@
     <Background gap={18} patternColor="var(--color-border)" />
     <Controls showLock={false} />
   </SvelteFlow>
+  <!-- The canvas shares the page background, so panned content would
+       otherwise hard-stop at the container edge. Fade the top and left
+       edges to signal "the graph continues past here". z-index sits above
+       xyflow's elevated selected nodes (1000); controls are raised higher
+       in the style block below so they stay crisp. -->
+  <div
+    aria-hidden="true"
+    class="from-background pointer-events-none absolute inset-x-0 top-0 z-[1001] h-10 bg-linear-to-b to-transparent"
+  ></div>
+  <div
+    aria-hidden="true"
+    class="from-background pointer-events-none absolute inset-y-0 left-0 z-[1001] w-10 bg-linear-to-r to-transparent"
+  ></div>
 </div>
 
 <style>
@@ -818,5 +831,11 @@
      the hierarchy instead of decorative surface effects. */
   :global(.svelte-flow) {
     background: var(--color-background) !important;
+  }
+
+  /* Zoom controls sit inside the left edge-fade strip; raise them above the
+     fade overlays so they don't get veiled. */
+  :global(.svelte-flow__controls) {
+    z-index: 1010;
   }
 </style>

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -779,6 +779,12 @@
 </script>
 
 <div class="bg-background relative h-full min-h-0 w-full overflow-hidden">
+  <!-- Elevation is disabled because selecting a node otherwise raises it
+       (and, via subflow children, every edge touching it) to z 1000+,
+       painting spawn/return edges over other containers' step and
+       "N more steps" rows. With elevation off, edges tie with child rows
+       at z 1 and the node layer wins by paint order, so lines always pass
+       under rows. -->
   <SvelteFlow
     bind:nodes
     bind:edges
@@ -789,6 +795,8 @@
     nodesDraggable={false}
     nodesConnectable={false}
     elementsSelectable
+    elevateEdgesOnSelect={false}
+    elevateNodesOnSelect={false}
     zoomOnDoubleClick={false}
     minZoom={0.2}
     proOptions={{ hideAttribution: true }}

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -600,6 +600,9 @@
         draggable: false,
         connectable: false,
         selectable: true,
+        // Above the edge layer (z auto) so the container's protruding
+        // expand/collapse buttons aren't crossed by dashed spawn/return edges.
+        zIndex: 1,
         style: `width: ${c.width}px; height: ${c.height}px;`,
       });
       const items = itemsByWf.get(c.id!) ?? [];

--- a/apps/console/src/lib/components/WorkflowThroughputChart.svelte
+++ b/apps/console/src/lib/components/WorkflowThroughputChart.svelte
@@ -14,6 +14,45 @@
     running: number;
   };
 
+  type Bucket = { ts: Date; succeeded: number; errored: number; running: number };
+
+  const BAR_RADIUS = 5;
+
+  // Full-bar geometry for the custom marks: each bucket's stack is drawn as
+  // plain rects clipped by a rounded-top path spanning the whole bar, so the
+  // cap radius stays constant no matter how short the topmost segment is
+  // (layerchart's own rounding is per segment and vanishes on thin caps).
+  function barGeometry(
+    d: Bucket,
+    ctx: { xScale: any; yScale: any },
+    visible: { key: string; color?: string }[],
+  ) {
+    const w: number = ctx.xScale.bandwidth?.() ?? 0;
+    const x: number = ctx.xScale(d.ts);
+    let acc = 0;
+    const segs: { key: string; color?: string; y: number; h: number }[] = [];
+    for (const s of visible) {
+      const v = d[s.key as keyof Omit<Bucket, "ts">];
+      if (v <= 0) continue;
+      const y0 = acc;
+      acc += v;
+      segs.push({
+        key: s.key,
+        color: s.color,
+        y: ctx.yScale(acc),
+        h: ctx.yScale(y0) - ctx.yScale(acc),
+      });
+    }
+    if (segs.length === 0 || w <= 0) return null;
+    const yTop = ctx.yScale(acc);
+    const h = ctx.yScale(0) - yTop;
+    const r = Math.min(BAR_RADIUS, w / 2, h);
+    const clip =
+      `M${x},${yTop + r} a${r},${r} 0 0 1 ${r},${-r} h${w - 2 * r} ` +
+      `a${r},${r} 0 0 1 ${r},${r} v${h - r} h${-w} z`;
+    return { x, w, clip, segs };
+  }
+
   type Range = "24h" | "7d" | "30d";
 
   const RANGE_STORAGE_KEY = "argus.dashboard.throughput.range";
@@ -156,9 +195,32 @@
             format: xFormat,
           },
           yAxis: { format: () => "" },
-          bars: { strokeWidth: 0 },
         }}
       >
+        <!-- Custom marks: each bucket's stack renders as plain rects inside a
+             rounded-top clip spanning the whole bar, so the cap is visible no
+             matter which series is on top or how thin the top segment is. -->
+        {#snippet marks({ context })}
+          {@const visible = context.series.visibleSeries}
+          {#each data as d, i (d.ts.getTime())}
+            {@const geom = barGeometry(d, context, visible)}
+            {#if geom}
+              <clipPath id="wf-throughput-bar-{i}"><path d={geom.clip} /></clipPath>
+              <g clip-path="url(#wf-throughput-bar-{i})">
+                {#each geom.segs as seg (seg.key)}
+                  <rect
+                    x={geom.x}
+                    y={seg.y}
+                    width={geom.w}
+                    height={seg.h}
+                    fill={seg.color}
+                    opacity={context.series.isHighlighted(seg.key, true) ? 1 : 0.1}
+                  />
+                {/each}
+              </g>
+            {/if}
+          {/each}
+        {/snippet}
         {#snippet tooltip()}
           <Chart.Tooltip labelFormatter={tooltipLabelFormat} indicator="dashed" />
         {/snippet}

--- a/apps/console/src/lib/components/ui/button/button.svelte
+++ b/apps/console/src/lib/components/ui/button/button.svelte
@@ -8,7 +8,7 @@
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground hover:bg-primary/80",
-				outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:hover:bg-input/30 aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent",
+				outline: "bg-card shadow-surface hover:bg-muted hover:text-foreground dark:hover:bg-input/30 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
 				ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				destructive: "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",

--- a/apps/console/src/lib/components/ui/card/card.svelte
+++ b/apps/console/src/lib/components/ui/card/card.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="card"
 	data-size={size}
-	class={cn("border-border bg-card text-card-foreground gap-5 overflow-hidden rounded-lg border py-5 text-sm shadow-none has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col", className)}
+	class={cn("bg-card text-card-foreground shadow-surface gap-5 overflow-hidden rounded-lg py-5 text-sm has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/apps/console/src/lib/components/ui/sidebar/sidebar-group-label.svelte
+++ b/apps/console/src/lib/components/ui/sidebar/sidebar-group-label.svelte
@@ -15,7 +15,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			"text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-xl px-3 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+			"text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-xl px-3 text-xs font-medium transition-[margin,opacity] duration-150 ease-out group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
 			className
 		),
 		"data-slot": "sidebar-group-label",

--- a/apps/console/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/apps/console/src/lib/components/ui/sidebar/sidebar.svelte
@@ -91,7 +91,7 @@
 				// Adjust the padding for floating and inset variants.
 				variant === "floating" || variant === "inset"
 					? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s",
+					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
 				className
 			)}
 			{...restProps}

--- a/apps/console/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/apps/console/src/lib/components/ui/sidebar/sidebar.svelte
@@ -73,7 +73,7 @@
 		<div
 			data-slot="sidebar-gap"
 			class={cn(
-				"transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent",
+				"transition-[width] duration-150 ease-out relative w-(--sidebar-width) bg-transparent",
 				"group-data-[collapsible=offcanvas]:w-0",
 				"group-data-[side=right]:rotate-180",
 				variant === "floating" || variant === "inset"
@@ -84,7 +84,7 @@
 		<div
 			data-slot="sidebar-container"
 			class={cn(
-				"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+				"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-150 ease-out md:flex",
 				side === "left"
 					? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"
 					: "end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]",

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -27,7 +27,6 @@
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
   import * as Breadcrumb from "$lib/components/ui/breadcrumb/index.js";
   import * as Sheet from "$lib/components/ui/sheet/index.js";
-  import { Separator } from "$lib/components/ui/separator/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
   import * as Table from "$lib/components/ui/table/index.js";
   import GithubLink from "$lib/components/GithubLink.svelte";
@@ -418,7 +417,7 @@
                           No missing tables, missing columns, or type mismatches were detected.
                         </p>
                       {:else}
-                        <div class="overflow-x-auto rounded-lg border">
+                        <div class="shadow-surface overflow-x-auto rounded-lg">
                           <Table.Root>
                             <Table.Header class="bg-muted/40">
                               <Table.Row class="hover:bg-muted/40">
@@ -481,10 +480,9 @@
 
   <Sidebar.Inset>
     <header
-      class="bg-background sticky top-0 z-10 flex h-12 shrink-0 items-center gap-2 border-b px-4"
+      class="bg-background sticky top-0 z-10 flex h-11 shrink-0 items-center gap-3 px-4"
     >
       <Sidebar.Trigger class="-ml-1" />
-      <Separator orientation="vertical" class="mr-2 !h-4" />
       <Breadcrumb.Root class="min-w-0 flex-1 overflow-hidden">
         <Breadcrumb.List class="flex-nowrap overflow-hidden">
           {#each breadcrumb.items as item, i (i)}
@@ -554,7 +552,6 @@
       </Breadcrumb.Root>
       <div class="ml-auto flex flex-none items-center gap-1">
         <GithubLink />
-        <Separator orientation="vertical" class="mx-1 !h-4" />
         <Button
           variant="ghost"
           size="icon-sm"

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -273,7 +273,7 @@
                 <Sidebar.MenuButton
                   size="lg"
                   tooltipContent="Connection details"
-                  class="h-auto min-h-12 items-start py-2"
+                  class="h-auto min-h-12 items-start py-2 group-data-[collapsible=icon]:min-h-0 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:p-2!"
                   {...props}
                 >
                   <Database

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -179,7 +179,7 @@
   {/if}
 
   <div
-    class="*:data-[slot=card]:relative *:data-[slot=card]:cursor-pointer *:data-[slot=card]:transition-colors *:data-[slot=card]:hover:border-foreground/20 *:data-[slot=card]:hover:bg-muted/20 grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4"
+    class="*:data-[slot=card]:relative *:data-[slot=card]:cursor-pointer *:data-[slot=card]:transition-shadow *:data-[slot=card]:hover:shadow-surface-lg grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4"
   >
     <Card.Root>
       <a
@@ -198,13 +198,13 @@
         </Card.Title>
         <Card.Action class="flex flex-col items-end gap-1">
           <a href={inFlightHref} class="relative z-10 hover:opacity-80">
-            <Badge variant="outline" class="gap-1">
+            <Badge variant="secondary" class="bg-status-running/15 text-status-running gap-1">
               <ActivityIcon class="size-3" />
               {stats?.in_flight ?? "—"} in flight
             </Badge>
           </a>
           <a href={enqueuedHref} class="relative z-10 hover:opacity-80">
-            <Badge variant="outline" class="gap-1">
+            <Badge variant="secondary" class="bg-status-queued/15 text-status-queued gap-1">
               <ListTodoIcon class="size-3" />
               {stats?.enqueued ?? "—"} queued
             </Badge>
@@ -241,7 +241,7 @@
           </span>
         </Card.Title>
         <Card.Action>
-          <Badge variant="outline" class="gap-1">
+          <Badge variant="secondary" class="gap-1">
             <BellIcon class="size-3" />
             Inbox
           </Badge>
@@ -269,7 +269,7 @@
           </span>
         </Card.Title>
         <Card.Action>
-          <Badge variant="outline" class="gap-1">
+          <Badge variant="secondary" class="gap-1">
             <CalendarClockIcon class="size-3" />
             Cron
           </Badge>
@@ -295,7 +295,7 @@
           </span>
         </Card.Title>
         <Card.Action>
-          <Badge variant="outline" class="gap-1 tabular-nums">
+          <Badge variant="secondary" class="gap-1 tabular-nums">
             <LayersIcon class="size-3" />
             {stats?.total_queues ?? "—"}
           </Badge>

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -144,7 +144,7 @@
   });
 </script>
 
-<div class="@container/main flex flex-col gap-4 p-4 md:gap-5 md:p-5">
+<div class="@container/main flex flex-col gap-4 p-4 pt-0 md:gap-5 md:p-5 md:pt-0">
   {#if connectionAlert}
     <button
       type="button"
@@ -301,16 +301,16 @@
           </Badge>
         </Card.Action>
       </Card.Header>
-      <Card.Footer class="mt-auto flex-col items-stretch gap-1.5 text-sm">
+      <Card.Footer class="mt-auto flex-col items-stretch gap-1.5 pr-3 text-sm">
         {#if queues === null}
           <div class="text-muted-foreground text-xs">Loading…</div>
         {:else if topQueues.length === 0}
           <div class="text-muted-foreground text-xs">No queues registered.</div>
         {:else}
-          <div class="text-muted-foreground flex items-center gap-3 text-xs font-medium tracking-wide uppercase">
+          <div class="text-muted-foreground flex items-center gap-3 text-[10px] font-medium tracking-wide uppercase">
             <span class="min-w-0 flex-1"></span>
-            <span class="text-status-queued/80 w-10 flex-none text-right">Queued</span>
-            <span class="text-status-running/80 w-10 flex-none text-right">Running</span>
+            <span class="text-status-queued/80 w-11 flex-none text-right">Queued</span>
+            <span class="text-status-running/80 w-12 flex-none text-right">Running</span>
           </div>
           {#each topQueues as q (q.queue_id)}
             <a
@@ -325,12 +325,12 @@
                 {q.name}
               </span>
               <span
-                class="text-status-queued w-10 flex-none text-right font-mono font-semibold tabular-nums"
+                class="text-status-queued w-11 flex-none text-right font-mono font-semibold tabular-nums"
               >
                 {q.enqueued}
               </span>
               <span
-                class="text-status-running w-10 flex-none text-right font-mono font-semibold tabular-nums"
+                class="text-status-running w-12 flex-none text-right font-mono font-semibold tabular-nums"
               >
                 {q.running}
               </span>

--- a/apps/console/src/routes/notifications/+page.svelte
+++ b/apps/console/src/routes/notifications/+page.svelte
@@ -434,7 +434,7 @@
             <p class="text-muted-foreground text-sm">No message payload.</p>
           {:else}
             <pre
-              class="border-border bg-muted/40 max-h-[60vh] overflow-auto rounded-lg border p-3 font-mono text-xs whitespace-pre-wrap break-words">{displayedMessage}</pre>
+              class="bg-muted/40 max-h-[60vh] overflow-auto rounded-lg p-3 font-mono text-xs whitespace-pre-wrap break-words">{displayedMessage}</pre>
             {#if messagePayload.decoded === null && selected.serialization && selected.serialization.toLowerCase().includes("pickle")}
               <p class="text-muted-foreground text-xs">
                 Pickled Python value couldn't be decoded safely (likely a custom class).

--- a/apps/console/src/routes/notifications/+page.svelte
+++ b/apps/console/src/routes/notifications/+page.svelte
@@ -401,12 +401,12 @@
                     <Copy class="h-3.5 w-3.5" />
                   {/if}
                 </button>
-                <div class="bg-muted flex items-center rounded-md p-0.5">
+                <div class="flex items-center gap-0.5">
                   <button
                     type="button"
                     class="rounded px-2 py-0.5 text-xs font-medium transition
                       {effectiveMode === 'raw'
-                        ? 'bg-background text-foreground shadow-xs'
+                        ? 'bg-card text-foreground shadow-surface'
                         : 'text-muted-foreground hover:text-foreground'}"
                     onclick={() => (preferredMode = "raw")}
                   >
@@ -417,7 +417,7 @@
                     disabled={messagePayload.decoded === null}
                     class="rounded px-2 py-0.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-40
                       {effectiveMode === 'decoded'
-                        ? 'bg-background text-foreground shadow-xs'
+                        ? 'bg-card text-foreground shadow-surface'
                         : 'text-muted-foreground enabled:hover:text-foreground'}"
                     onclick={() => (preferredMode = "decoded")}
                     title={messagePayload.decoded === null

--- a/apps/console/src/routes/notifications/+page.svelte
+++ b/apps/console/src/routes/notifications/+page.svelte
@@ -401,7 +401,7 @@
                     <Copy class="h-3.5 w-3.5" />
                   {/if}
                 </button>
-                <div class="flex items-center gap-0.5">
+                <div class="bg-muted flex items-center gap-0.5 rounded-md p-0.5">
                   <button
                     type="button"
                     class="rounded px-2 py-0.5 text-xs font-medium transition

--- a/apps/console/src/routes/workflows/+page.svelte
+++ b/apps/console/src/routes/workflows/+page.svelte
@@ -640,7 +640,7 @@
     <DateRangePicker bind:value={dateRange} placeholder="Started" />
 
     <label
-      class="border-border bg-background hover:bg-muted hover:text-foreground text-foreground flex h-9 cursor-pointer items-center gap-1.5 rounded-md border px-3 text-sm font-medium select-none dark:bg-transparent dark:hover:bg-input/30"
+      class="bg-card shadow-surface hover:bg-muted hover:text-foreground text-foreground flex h-9 cursor-pointer items-center gap-1.5 rounded-md px-3 text-sm font-medium select-none dark:hover:bg-input/30"
       title="Hide scheduled-workflow runs (workflow IDs starting with 'sched-')"
     >
       <Checkbox checked={hideScheduled} onCheckedChange={(v) => setHideScheduled(!!v)} />

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { page } from "$app/state";
+  import PanelRightOpen from "@lucide/svelte/icons/panel-right-open";
   import ResultPane, {
     type ResultData,
     type WorkflowEventEntry,
@@ -79,56 +80,25 @@
   let dragging = $state(false);
   let dragStartX = 0;
   let dragStartWidth = 0;
-  // Width to restore if a drag-from-collapsed releases below MIN_RIGHT.
-  let savedRightWidth = 0;
-  let dragFromCollapsed = false;
   const MIN_RIGHT = 280;
   const MAX_RIGHT = 900;
   const RESIZE_STEP = 24;
-  // Width left visible when collapsed: just enough to show the eyebrow's
-  // 32px (icon-sm) toggle button + the eyebrow's px-4 horizontal padding.
-  const PEEK_WIDTH = 64;
-
-  const effectiveRightWidth = $derived(collapsed ? PEEK_WIDTH : rightWidth);
 
   function onHandlePointerDown(e: PointerEvent) {
     dragging = true;
     dragStartX = e.clientX;
-    dragFromCollapsed = collapsed;
-    if (collapsed) {
-      // Drag from collapsed: anchor the drag at the peek width so the pane
-      // grows out of the peek under the cursor instead of jumping straight
-      // to the saved expanded width.
-      savedRightWidth = rightWidth;
-      dragStartWidth = PEEK_WIDTH;
-      rightWidth = PEEK_WIDTH;
-      collapsed = false;
-    } else {
-      dragStartWidth = rightWidth;
-    }
+    dragStartWidth = rightWidth;
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }
 
   function onHandlePointerMove(e: PointerEvent) {
     if (!dragging) return;
     const delta = e.clientX - dragStartX;
-    const next = dragStartWidth - delta;
-    // Drag-from-collapsed allows widths down to PEEK_WIDTH so the user can
-    // back out of an expand. Drag-from-expanded keeps MIN_RIGHT so the pane
-    // stays usable.
-    const min = dragFromCollapsed ? PEEK_WIDTH : MIN_RIGHT;
-    rightWidth = Math.max(min, Math.min(MAX_RIGHT, next));
+    rightWidth = Math.max(MIN_RIGHT, Math.min(MAX_RIGHT, dragStartWidth - delta));
   }
 
   function onHandlePointerUp(e: PointerEvent) {
     dragging = false;
-    if (dragFromCollapsed && rightWidth < MIN_RIGHT) {
-      // Released without expanding past MIN_RIGHT — snap back to collapsed
-      // and restore the previously-expanded width for next expand.
-      collapsed = true;
-      rightWidth = savedRightWidth;
-    }
-    dragFromCollapsed = false;
     (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
   }
 
@@ -138,16 +108,8 @@
 
     const step = e.shiftKey ? RESIZE_STEP * 2 : RESIZE_STEP;
     if (e.key === "ArrowLeft") {
-      if (collapsed) {
-        collapsed = false;
-        rightWidth = Math.max(MIN_RIGHT, rightWidth);
-        return;
-      }
       rightWidth = Math.min(MAX_RIGHT, rightWidth + step);
-      return;
-    }
-
-    if (!collapsed) {
+    } else {
       rightWidth = Math.max(MIN_RIGHT, rightWidth - step);
     }
   }
@@ -336,43 +298,56 @@
         onSelect={(s) => (selection = s)}
       />
     </div>
-    <div
-      class="bg-border relative hidden w-px flex-none lg:block"
-      class:!bg-primary={dragging}
-    >
+    {#if collapsed}
+      <!-- Collapsed: the pane gives its space back to the graph and leaves
+           only this floating expand button behind. -->
       <button
         type="button"
-        aria-label={`Resize result pane. ${collapsed ? "Currently collapsed" : `Current width ${effectiveRightWidth} pixels`}. Use Left and Right arrow keys.`}
-        aria-keyshortcuts="ArrowLeft ArrowRight"
-        title="Resize details pane with Left and Right arrow keys"
-        onpointerdown={onHandlePointerDown}
-        onpointermove={onHandlePointerMove}
-        onpointerup={onHandlePointerUp}
-        onkeydown={onHandleKeyDown}
-        class="bg-card border-border text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-ring absolute top-1/2 left-1/2 z-10 flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 cursor-col-resize items-center justify-center rounded-full border shadow-sm focus-visible:ring-2 focus-visible:outline-none"
-        class:!bg-primary={dragging}
-        class:!border-primary={dragging}
-        class:!text-primary-foreground={dragging}
+        onclick={() => (collapsed = false)}
+        title="Expand details pane"
+        aria-label="Expand details pane"
+        class="bg-card shadow-surface-lg text-muted-foreground hover:text-foreground hover:bg-muted absolute top-3 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-lg"
       >
-        <span class="flex h-3 items-center gap-0.5">
-          <span class="bg-current h-full w-px"></span>
-          <span class="bg-current h-full w-px"></span>
-        </span>
+        <PanelRightOpen class="size-4" />
       </button>
-    </div>
+    {:else}
+      <div
+        class="relative hidden w-px flex-none lg:block"
+        class:!bg-primary={dragging}
+      >
+        <button
+          type="button"
+          aria-label={`Resize result pane. Current width ${rightWidth} pixels. Use Left and Right arrow keys.`}
+          aria-keyshortcuts="ArrowLeft ArrowRight"
+          title="Resize details pane with Left and Right arrow keys"
+          onpointerdown={onHandlePointerDown}
+          onpointermove={onHandlePointerMove}
+          onpointerup={onHandlePointerUp}
+          onkeydown={onHandleKeyDown}
+          class="bg-card shadow-surface text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-ring absolute top-1/2 left-1/2 z-10 flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 cursor-col-resize items-center justify-center rounded-full focus-visible:ring-2 focus-visible:outline-none"
+          class:!bg-primary={dragging}
+          class:!text-primary-foreground={dragging}
+        >
+          <span class="flex h-3 items-center gap-0.5">
+            <span class="bg-current h-full w-px"></span>
+            <span class="bg-current h-full w-px"></span>
+          </span>
+        </button>
+      </div>
+    {/if}
     <div
-      class="absolute inset-y-0 right-0 w-[var(--result-pane-width)] max-w-[calc(100%-3rem)] flex-none overflow-hidden border-l shadow-lg lg:static lg:border-l-0 lg:shadow-none"
+      class="shadow-surface-lg absolute inset-y-3 right-3 w-[var(--result-pane-width)] max-w-[calc(100%-3rem)] flex-none overflow-hidden rounded-xl lg:static lg:my-3 lg:mr-3 lg:ml-2"
+      class:hidden={collapsed}
       class:transition-[width]={!dragging}
       class:duration-200={!dragging}
       class:ease-out={!dragging}
-      style="--result-pane-width: {effectiveRightWidth}px"
+      style="--result-pane-width: {rightWidth}px"
     >
       <ResultPane
         {selection}
         {result}
         loading={resultLoading}
         events={detail.events}
-        {collapsed}
         onToggleCollapse={() => (collapsed = !collapsed)}
       />
     </div>


### PR DESCRIPTION
Reworks the console's visual language from white-on-white panels with gray hairline borders to a soft canvas with borderless, shadow-separated surfaces.

## Shell
- Warm stone-family canvas background with white cards separated by a subtle shadow ring instead of borders (new \`shadow-surface\` / \`shadow-surface-lg\` tokens)
- Primary accent moves from violet-700 to a muted iris; queued-status purple gains hue separation from it
- Header loses its bottom border and separators; sidebar drops its border, renders the active item as a raised pill, and collapses at 150ms with easing; the collapsed rail renders the database status button like the other nav items

## Workflow graph
- Step nodes are flat full-width rows: no boxes, no per-step borders, no connecting lines (status dots and order carry the sequence)
- Workflow containers float as shadowed cards on a dotted canvas; containers paint above the dashed spawn/return edges so their collapse buttons are never crossed
- Top/left edge fadeouts signal where the canvas continues; contained with \`isolate\` so portaled tooltips stay on top
- Details pane is a floating rounded card that collapses to a single expand button, returning its space to the graph

## Dashboard
- Throughput chart bars get a rounded top cap drawn at the bar level (clip path over the stack), so the cap shows for every bar regardless of which series is on top or how thin it is
- Top queues card fits its column headers, aligns value columns, and trades right padding for queue-name space

Dark mode keeps the same structure with hairline rings in place of shadows. Lint, 17 unit tests, and the production build all pass; verified visually in both themes against the live demo stack.