### PR TITLE
fix: workflow ids containing slashes break the detail page and step selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   index.html with a 200 that the console then failed to parse as JSON.
 - A failed lazy result fetch now renders inside the result pane instead of
   replacing the whole workflow detail page with an error banner.
+- Clicking a step in the workflow graph now selects it when the workflow id
+  contains a slash. `handleNodeClick` split the composite node id
+  (`<workflow_id>/<function_id>`) on `/`, which mis-parsed such ids and
+  silently selected nothing; it now reads `node.parentId` and
+  `node.data.functionId`, both exact.
 
 ## [0.0.31] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Workflow ids containing slashes (e.g. `pr-review:owner/repo#20:v1`) no longer
+  break the detail page. `GET /api/workflows/{id}`, `.../result` and
+  `.../steps/{fn}/result` now take the id as a `:path` param — a
+  percent-encoded `%2F` is decoded before routing, so the segment param never
+  matched and the request fell through to the SPA catch-all, returning
+  index.html with a 200 that the console then failed to parse as JSON.
+- A failed lazy result fetch now renders inside the result pane instead of
+  replacing the whole workflow detail page with an error banner.
+
 ## [0.0.31] - 2026-07-17
 
 > **Tested against DBOS 2.27.0.** See `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility; the dev fixture floor is now `dbos>=2.27.0`.

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -46,6 +46,7 @@
     selection,
     result,
     loading = false,
+    loadError = null,
     events = [],
     collapsed = false,
     onToggleCollapse,
@@ -53,6 +54,9 @@
     selection: FlowSelection;
     result: ResultData | null;
     loading?: boolean;
+    // A failed lazy result fetch is scoped to this pane — the surrounding
+    // detail page stays rendered.
+    loadError?: string | null;
     events?: WorkflowEventEntry[];
     collapsed?: boolean;
     onToggleCollapse?: () => void;
@@ -533,6 +537,14 @@
       {#if loading}
         <div class="text-muted-foreground flex flex-1 items-center justify-center p-6 text-sm">
           Loading…
+        </div>
+      {:else if loadError}
+        <div class="flex flex-1 items-start justify-center p-4">
+          <div
+            class="border-destructive/30 bg-destructive/5 text-destructive rounded-md border p-3 text-sm"
+          >
+            Couldn't load result: {loadError}
+          </div>
         </div>
       {:else if payload.kind === "none"}
         <div class="text-muted-foreground flex flex-1 items-center justify-center p-6 text-sm">

--- a/apps/console/src/lib/components/WorkflowFlow.svelte
+++ b/apps/console/src/lib/components/WorkflowFlow.svelte
@@ -166,6 +166,10 @@
     return null;
   }
 
+  // Composite node id, safe to *build* but never to parse back apart: workflow
+  // ids are app-chosen and routinely contain `/` (e.g. `pr-review:owner/repo#20:v1`),
+  // so splitting on the separator can't recover the two halves. Read
+  // `node.parentId` / `node.data.functionId` instead — see `handleNodeClick`.
   function stepNodeId(workflowId: string, functionId: number): string {
     return `${workflowId}/${functionId}`;
   }
@@ -760,8 +764,11 @@
       return;
     }
     if (node.type === "step") {
-      const [wfId, fnStr] = node.id.split("/");
-      const fnId = Number(fnStr);
+      // `parentId` is the owning workflow id verbatim and `data.functionId` the
+      // step's id — both exact. Splitting `node.id` on "/" would mis-parse any
+      // workflow id containing a slash and silently select nothing.
+      const wfId = node.parentId;
+      const fnId = (node.data as { functionId: number }).functionId;
       const step = steps.find((s) => s.workflow_id === wfId && s.function_id === fnId);
       if (step) onSelect({ kind: "step", step });
     }

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -309,7 +309,7 @@
       { label: "Workflows", href: "/workflows/", icon: "workflow", tooltip: "Workflows" },
       ...chain.map((w) => ({
         label: w.name ?? w.workflow_id,
-        href: `/workflows/${w.workflow_id}`,
+        href: `/workflows/${encodeURIComponent(w.workflow_id)}/`,
         status: w.status,
         tooltip: w.workflow_id,
       })),

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -46,6 +46,9 @@
   };
   let result = $state<ResultData | null>(null);
   let resultLoading = $state(false);
+  // Kept separate from `error` so a failed result fetch degrades to a message
+  // inside the result pane instead of replacing the whole detail page.
+  let resultError = $state<string | null>(null);
   // Token guards against stale fetches landing after a faster, newer click.
   let resultFetchToken = 0;
 
@@ -169,6 +172,7 @@
     resultCache.clear();
     result = null;
     resultLoading = false;
+    resultError = null;
     if (!id) return;
 
     const apply = (data: unknown) => {
@@ -230,6 +234,7 @@
     if (!sel) {
       result = null;
       resultLoading = false;
+      resultError = null;
       return;
     }
     let key: string;
@@ -251,6 +256,7 @@
     if (cached) {
       result = cached;
       resultLoading = false;
+      resultError = null;
       return;
     }
 
@@ -260,12 +266,14 @@
       resultCache.set(key, EMPTY_RESULT);
       result = EMPTY_RESULT;
       resultLoading = false;
+      resultError = null;
       return;
     }
 
     const myToken = ++resultFetchToken;
     result = null;
     resultLoading = true;
+    resultError = null;
     fetch(url)
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -274,11 +282,12 @@
         resultCache.set(key, body);
         result = body;
         resultLoading = false;
+        resultError = null;
       })
       .catch((e) => {
         if (myToken !== resultFetchToken) return;
         resultLoading = false;
-        error = e instanceof Error ? e.message : String(e);
+        resultError = e instanceof Error ? e.message : String(e);
       });
   });
 
@@ -371,6 +380,7 @@
         {selection}
         {result}
         loading={resultLoading}
+        loadError={resultError}
         events={detail.events}
         {collapsed}
         onToggleCollapse={() => (collapsed = !collapsed)}

--- a/packages/server/dbos_argus/main.py
+++ b/packages/server/dbos_argus/main.py
@@ -509,18 +509,42 @@ async def fetch_workflow_detail(workflow_id: str) -> WorkflowDetail | None:
     return _build_workflow_detail(detail, workflow_id)
 
 
-@app.get("/api/workflows/{workflow_id}")
-async def get_workflow(workflow_id: str) -> WorkflowDetail:
-    result = await fetch_workflow_detail(workflow_id)
-    if result is None:
-        raise HTTPException(status_code=404, detail="workflow not found")
-    return result
+# The three routes below take the workflow id as a `:path` param, not the
+# default segment param, and are declared most-specific-first because Starlette
+# matches in declaration order.
+#
+# Workflow ids are app-chosen and routinely contain slashes (e.g.
+# `pr-review:owner/repo#20:v1`). A client percent-encodes them, but the ASGI
+# server decodes `%2F` back to `/` before routing, so a segment param never
+# matches and the request falls through to the SPA catch-all at the bottom of
+# this module — returning index.html with a 200, which the console then fails
+# to parse as JSON. `:path` accepts the embedded slashes; the literal `/result`
+# and `/steps/{id}/result` suffixes keep the greedy match anchored.
+#
+# Lazily fetches a single step row's output/error. Declared before the workflow
+# `/result` route below, whose greedy `:path` would otherwise consume the
+# `/steps/{function_id}` part and treat it as the tail of the workflow id.
+# Same lazy-load pattern as that route — indexed by (workflow_uuid, function_id).
+@app.get("/api/workflows/{workflow_id:path}/steps/{function_id}/result")
+async def get_step_result(workflow_id: str, function_id: int) -> StepResult:
+    row = await db.get_step_result(workflow_id, function_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="step not found")
+    return StepResult(
+        workflow_id=workflow_id,
+        function_id=function_id,
+        output=row.output,
+        error=row.error,
+        serialization=row.serialization,
+        output_decoded=decode_dbos_value(row.output, row.serialization),
+        error_decoded=decode_dbos_value(row.error, row.serialization),
+    )
 
 
 # Lazily fetches the output/error payload for a single workflow row. Split out
 # from the detail endpoint so workflow detail page loads stay small even when
 # a family contains many workflows with multi-MB pickled outputs.
-@app.get("/api/workflows/{workflow_id}/result")
+@app.get("/api/workflows/{workflow_id:path}/result")
 async def get_workflow_result(workflow_id: str) -> WorkflowResult:
     row = await db.get_workflow_result(workflow_id)
     if row is None:
@@ -535,22 +559,14 @@ async def get_workflow_result(workflow_id: str) -> WorkflowResult:
     )
 
 
-# Lazily fetches a single step row's output/error. Companion to the workflow
-# result endpoint — same lazy-load pattern, indexed by (workflow_uuid, function_id).
-@app.get("/api/workflows/{workflow_id}/steps/{function_id}/result")
-async def get_step_result(workflow_id: str, function_id: int) -> StepResult:
-    row = await db.get_step_result(workflow_id, function_id)
-    if row is None:
-        raise HTTPException(status_code=404, detail="step not found")
-    return StepResult(
-        workflow_id=workflow_id,
-        function_id=function_id,
-        output=row.output,
-        error=row.error,
-        serialization=row.serialization,
-        output_decoded=decode_dbos_value(row.output, row.serialization),
-        error_decoded=decode_dbos_value(row.error, row.serialization),
-    )
+# Declared last of the three: its `:path` param would otherwise swallow the
+# `/result` and `/steps/{id}/result` suffixes above.
+@app.get("/api/workflows/{workflow_id:path}")
+async def get_workflow(workflow_id: str) -> WorkflowDetail:
+    result = await fetch_workflow_detail(workflow_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="workflow not found")
+    return result
 
 
 class DashboardStats(BaseModel):

--- a/packages/server/tests/test_workflow_id_routing.py
+++ b/packages/server/tests/test_workflow_id_routing.py
@@ -1,0 +1,79 @@
+"""Workflow ids are app-chosen and routinely contain slashes — DBOS itself
+imposes no character restriction, and ids like `pr-review:owner/repo#20:v1`
+are common. A client percent-encodes them, but the ASGI server decodes `%2F`
+back to `/` before routing, so these routes must use `:path` params. When they
+used segment params the request fell through to the SPA catch-all and returned
+index.html with a 200, which the console then failed to parse as JSON.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dbos_argus.db.rows import ResultRow
+from dbos_argus.main import app
+from fastapi.testclient import TestClient
+
+# Slash (the route-breaking one), `#` and `:` — all legal in a DBOS id and all
+# percent-encoded by the console's `encodeURIComponent`.
+SLASHED_ID = "pr-review:bookmd/agentflow-test#20:v1"
+ENCODED_ID = "pr-review%3Abookmd%2Fagentflow-test%2320%3Av1"
+
+
+@pytest.fixture
+def seen(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Stub the three db reads so these tests assert routing and param
+    decoding only — no schema or seed data needed."""
+    captured: dict[str, object] = {}
+    row = ResultRow(output=None, error='{"message": "boom"}', serialization="json")
+
+    async def get_workflow_result(workflow_id: str) -> ResultRow:
+        captured["workflow_id"] = workflow_id
+        return row
+
+    async def get_step_result(workflow_id: str, function_id: int) -> ResultRow:
+        captured["workflow_id"] = workflow_id
+        captured["function_id"] = function_id
+        return row
+
+    monkeypatch.setattr("dbos_argus.main.db.get_workflow_result", get_workflow_result)
+    monkeypatch.setattr("dbos_argus.main.db.get_step_result", get_step_result)
+    return captured
+
+
+def test_workflow_result_accepts_encoded_slashes(seen: dict[str, object]) -> None:
+    with TestClient(app) as client:
+        response = client.get(f"/api/workflows/{ENCODED_ID}/result")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert seen["workflow_id"] == SLASHED_ID
+    assert response.json()["workflow_id"] == SLASHED_ID
+
+
+def test_step_result_accepts_encoded_slashes(seen: dict[str, object]) -> None:
+    with TestClient(app) as client:
+        response = client.get(f"/api/workflows/{ENCODED_ID}/steps/7/result")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert seen["workflow_id"] == SLASHED_ID
+    assert seen["function_id"] == 7
+
+
+def test_workflow_detail_accepts_encoded_slashes(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def fetch(workflow_id: str) -> None:
+        captured["workflow_id"] = workflow_id
+        return None
+
+    monkeypatch.setattr("dbos_argus.main.fetch_workflow_detail", fetch)
+
+    with TestClient(app) as client:
+        response = client.get(f"/api/workflows/{ENCODED_ID}")
+
+    # A 404 (not the SPA's 200 + text/html) is the proof the route matched:
+    # the handler ran and reported "not found" for the fully decoded id.
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+    assert captured["workflow_id"] == SLASHED_ID


### PR DESCRIPTION
Workflow ids are app-chosen, and DBOS imposes no character restriction on them. Ids built from a repo path are common — the one I hit was `pr-review:owner/repo#20:v1`. A `/` in the id currently breaks the detail page in two separate places, one server-side and one client-side.

## Bug 1 — the detail page renders nothing but a JSON parse error

<img src="https://raw.githubusercontent.com/dh94/dbos-argus/pr-assets/slash-in-workflow-id/assets/before.png" width="900" alt="Before: the workflow detail page shows only 'Unexpected token '<', \"<!doctype \"... is not valid JSON'" />

### Root cause

The console does percent-encode the id (`encodeURIComponent`), but **the ASGI server decodes `%2F` back to `/` before Starlette routes the request**. `{workflow_id}` is a segment param, which never matches `/`, so the route doesn't match — and the request falls through to the SPA catch-all `/{full_path:path}` at the bottom of `main.py`, which happily returns `index.html` **with a 200**:

```
$ curl -so /dev/null -w '%{http_code} %{content_type}\n' \
    'localhost:8090/api/workflows/pr-review%3Aowner%2Frepo%2320%3Av1/result'
200 text/html; charset=utf-8      # <- index.html, not JSON

$ curl -so /dev/null -w '%{http_code} %{content_type}\n' \
    'localhost:8090/api/workflows/plain-id/result'
404 application/json              # <- route matched, as expected
```

The console then calls `res.json()` on a page of HTML and throws `Unexpected token '<', "<!doctype "...`.

Worth noting *why* the failure looks so total: the detail payload itself arrives fine over the realtime channel (the id travels in a JSON body, so it never touches URL routing). Only the lazy `/result` fetch is broken. But its `.catch` wrote to the page-level `error` state, and the template's top-level `{#if error}` replaced the entire view — so a missing result payload hid the step graph, the metadata pane, and everything else.

### Fix

**`:path` params, ordered most-specific-first** (`packages/server/dbos_argus/main.py`)

The three workflow-id routes now take the id as a `:path` param, which accepts embedded slashes. The literal `/result` and `/steps/{function_id}/result` suffixes keep the greedy match anchored.

Declaration order matters, since Starlette matches in order and `:path` is greedy. The step-result route must come first: with `/result` declared ahead of it, `…/steps/7/result` matched the *workflow* result route with `workflow_id` = `pr-review:owner/repo#20:v1/steps/7`. The added test caught exactly that on my first attempt, so it's now covered explicitly.

Final order: `/steps/{function_id}/result` → `/result` → bare detail.

**Scope result-fetch failures to the result pane** (`apps/console`)

New `resultError` state (page) / `loadError` prop (`ResultPane`), kept separate from `error`. A failed lazy fetch now degrades to a message inside the pane and leaves the rest of the page rendered.

<img src="https://raw.githubusercontent.com/dh94/dbos-argus/pr-assets/slash-in-workflow-id/assets/after.png" width="900" alt="After: the workflow detail page renders the step graph, metadata, and the decoded error payload" />

## Bug 2 — clicking a step selects nothing

Found while verifying the first fix: with the routing fixed, clicking a step in the graph still did nothing — no step details, no output, and no `/steps/{fn}/result` request in the network panel at all.

### Root cause

Same class of bug, this time in the console. Step nodes carry the composite id `<workflow_id>/<function_id>`, and `handleNodeClick` recovered the halves by parsing it:

```js
const [wfId, fnStr] = node.id.split("/");
```

For `pr-review:owner/repo#20:v1/4` that yields `wfId = "pr-review:owner"` and `fnStr = "repo#20:v1"` → `fnId = NaN`. The lookup misses, and the handler returns without selecting anything — silently, since a missed `find` is indistinguishable from a node that legitimately has no step.

### Fix

Read `node.parentId` (the owning workflow id, verbatim) and `node.data.functionId`. Both are already on the node and are exact, so nothing needs to parse the separator back out. `stepNodeId` gained a comment noting the id is safe to build but never to parse.

<img src="https://raw.githubusercontent.com/dh94/dbos-argus/pr-assets/slash-in-workflow-id/assets/step-click.png" width="900" alt="After: clicking a step shows 'STEP #1 DETAILS' with the step's decoded output" />

## Tests

`packages/server/tests/test_workflow_id_routing.py` — three tests covering the encoded id round-tripping through each of the three routes. They stub the `db` reads, so they assert routing and param decoding only and need no schema or seed data.

Each test asserts the response is `application/json`, not just that the status is 2xx/404 — the whole failure mode in bug 1 was a **200 of the wrong content type**, so a status-only assertion would have passed against the bug.

I did not add an automated test for bug 2, and want to be upfront about it: `handleNodeClick` is internal to a ~900-line component, and the repo has no component-test harness (the existing vitest suites cover `$lib/*.ts` modules). Extracting a seam purely for this felt out of proportion to a three-line fix, so it's verified manually below. Happy to add one if you'd like — either an exported resolver in `$lib` with a unit test, or an e2e case in `apps/console/e2e`.

## Verification

- `pnpm run lint` — clean (ruff, ruff format, tsc, svelte-check: 0 errors, 0 warnings)
- `pnpm run test` — 90 passed
- `pnpm run build` — clean
- Manually verified in the browser against a real DBOS Postgres database with slash-containing workflow ids: the detail page loads, step clicks select and load `/steps/{fn}/result`, and both output and error payloads decode.
- The screenshots above come from a scratch SQLite DB seeded with a synthetic id (`pr-review:acme/widgets#42:v1`). "Before" is `dbos-argus@0.0.31` from PyPI, "after" is this branch, both pointed at the same DB.

## Notes

- No new dependencies, no schema changes, and the fix stays entirely on the read path.
- URL shapes are unchanged — this only widens what the existing paths accept, so no console or API consumer needs to change.
- One pathological case remains out of reach by construction: an id that itself ends in `/result` or contains `/steps/<int>/result` would still be mis-split. Fully fixing that means moving the id out of the path (into a query param), which would be a breaking API change — happy to do that instead if you'd prefer it.
- Unrelated, spotted while testing: `DBOS.sleep` steps render a duration of `56550y`, and an in-flight workflow shows `DURATION 0ms`. Not touched here; I can open separate issues if they aren't already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqRN2NJ388RqFfGwfoTBR3
