### PR TITLE
fix: DBOS.sleep duration renders ~1000x too large for TypeScript-SDK apps

### DIFF
--- a/packages/server/dbos_argus/main.py
+++ b/packages/server/dbos_argus/main.py
@@ -411,10 +411,24 @@ class StepResult(BaseModel):
 
 
 # DBOS.sleep rows store their wakeup time as a numeric string in `output`
-# (unix seconds, JSON-encoded even under py_pickle serialization). Subtracting
-# the row's `started_at` gives the originally requested duration in ms,
-# independent of how long the sleep actually elapsed in wall time. Returns
-# None for non-sleep rows or when the value isn't parseable as a float.
+# (JSON-encoded even under py_pickle serialization). Subtracting the row's
+# `started_at` gives the originally requested duration in ms, independent of
+# how long the sleep actually elapsed in wall time.
+#
+# The unit is SDK-dependent, so we can't assume one:
+#   - dbos (Python) records `time.time() + seconds`   -> unix SECONDS
+#   - @dbos-inc/dbos-sdk (TS) records `endTimeMs`     -> unix MILLISECONDS
+# Reading a TS row as seconds inflates the duration ~1000x (a 14-day sleep
+# renders as ~56550 years).
+#
+# `started_at_epoch_ms` is always ms, which disambiguates: a seconds-valued
+# wakeup is ~1000x smaller than the ms epoch, so reading it as ms lands far
+# before the step started and yields a negative duration. Keep whichever
+# interpretations put the wakeup at-or-after the start, then take the smaller
+# — the wrong one is always the wildly inflated one.
+#
+# Returns None for non-sleep rows, unparseable values, or when neither
+# interpretation yields a non-negative duration.
 def _sleep_requested_ms(step: StepRow) -> int | None:
     if (
         step.function_name != "DBOS.sleep"
@@ -423,11 +437,14 @@ def _sleep_requested_ms(step: StepRow) -> int | None:
     ):
         return None
     try:
-        wake_ms = float(step.sleep_output_raw) * 1000
+        raw = float(step.sleep_output_raw)
     except (TypeError, ValueError):
         return None
-    requested = round(wake_ms - step.started_at_epoch_ms)
-    return int(requested) if requested >= 0 else None
+    as_ms = raw  # TS SDK: already milliseconds
+    as_seconds_ms = raw * 1000  # Python SDK: seconds -> milliseconds
+    candidates = [round(wake_ms - step.started_at_epoch_ms) for wake_ms in (as_ms, as_seconds_ms)]
+    plausible = [c for c in candidates if c >= 0]
+    return int(min(plausible)) if plausible else None
 
 
 # Walks up parent_workflow_id to find the topmost ancestor (or the workflow

--- a/packages/server/tests/test_sleep_duration.py
+++ b/packages/server/tests/test_sleep_duration.py
@@ -1,0 +1,89 @@
+"""`DBOS.sleep` rows store their wakeup time in `output`, but the unit differs
+by SDK: the Python SDK records `time.time() + seconds` (unix seconds) while the
+TS SDK records `endTimeMs` (unix milliseconds). Reading a TS row as seconds
+inflated the duration ~1000x — a 14-day sleep rendered as ~56550 years.
+"""
+
+from __future__ import annotations
+
+from dbos_argus.db.rows import StepRow
+from dbos_argus.main import _sleep_requested_ms
+
+# 2026-07-27T11:27:16Z — a plausible `started_at_epoch_ms` for both cases.
+START_MS = 1_785_151_636_819
+FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000
+
+
+def step(sleep_output_raw: str | None, started_at_epoch_ms: int | None = START_MS) -> StepRow:
+    return StepRow(
+        workflow_uuid="wf-1",
+        function_id=18,
+        function_name="DBOS.sleep",
+        has_output=True,
+        has_error=False,
+        child_workflow_id=None,
+        started_at_epoch_ms=started_at_epoch_ms,
+        completed_at_epoch_ms=started_at_epoch_ms,
+        event_key=None,
+        sleep_output_raw=sleep_output_raw,
+    )
+
+
+def test_typescript_sdk_millisecond_wakeup() -> None:
+    """TS SDK: `output` is already ms. Read as seconds this returned
+    ~1.786e15 ms (~56550 years) instead of 14 days."""
+    wake_ms = START_MS + FOURTEEN_DAYS_MS
+    assert _sleep_requested_ms(step(str(wake_ms))) == FOURTEEN_DAYS_MS
+
+
+def test_python_sdk_second_wakeup() -> None:
+    """Python SDK: `output` is unix seconds, as a float string."""
+    wake_seconds = (START_MS + 500) / 1000
+    assert _sleep_requested_ms(step(str(wake_seconds))) == 500
+
+
+def test_python_sdk_integral_second_wakeup() -> None:
+    """Seconds without a fractional part must not be mistaken for ms. START_MS
+    isn't a whole second, so the result lands within 1s of the requested 30s."""
+    wake_seconds = START_MS // 1000 + 30
+    got = _sleep_requested_ms(step(str(wake_seconds)))
+    assert got is not None
+    assert abs(got - 30_000) < 1000
+
+
+def test_zero_duration_sleep() -> None:
+    """DBOS records `DBOS.sleep` with start == wakeup for a 0s sleep."""
+    assert _sleep_requested_ms(step(str(START_MS))) == 0
+
+
+def test_wakeup_before_start_returns_none() -> None:
+    """Neither interpretation is non-negative — don't invent a duration."""
+    assert _sleep_requested_ms(step("1")) is None
+
+
+def test_non_sleep_step_returns_none() -> None:
+    row = StepRow(
+        workflow_uuid="wf-1",
+        function_id=3,
+        function_name="checkout",
+        has_output=True,
+        has_error=False,
+        child_workflow_id=None,
+        started_at_epoch_ms=START_MS,
+        completed_at_epoch_ms=START_MS,
+        event_key=None,
+        sleep_output_raw=str(START_MS),
+    )
+    assert _sleep_requested_ms(row) is None
+
+
+def test_unparseable_output_returns_none() -> None:
+    assert _sleep_requested_ms(step("not-a-number")) is None
+
+
+def test_missing_output_returns_none() -> None:
+    assert _sleep_requested_ms(step(None)) is None
+
+
+def test_missing_start_returns_none() -> None:
+    assert _sleep_requested_ms(step(str(START_MS), started_at_epoch_ms=None)) is None


### PR DESCRIPTION
Follow-up to the note in #18 — the `DBOS.sleep` duration rendering you said would be welcome as a separate issue. It turned out to be a one-line unit bug, so here's a fix instead.

## The problem

Every `DBOS.sleep` step renders ~1000x too long for apps on the TypeScript SDK. A 4s retry backoff and a 14-day sleep both render as tens of thousands of years:

<img src="https://raw.githubusercontent.com/dh94/dbos-argus/pr-assets/slash-in-workflow-id/assets/sleep-before.png" width="900" alt="Before: two sleep steps rendering as 55753y and 55791y" />

## Root cause

`_sleep_requested_ms` reads the wakeup time in `output` as unix **seconds**, but the unit is SDK-dependent:

| SDK | Recorded value | Unit |
|---|---|---|
| `dbos` (Python), `_sys_db.py` `record_sleep` | `time.time() + seconds` | unix **seconds** |
| `@dbos-inc/dbos-sdk` (TS), `system_database.js` `#sleep` | `endTimeMs` | unix **milliseconds** |

The existing code was correct for Python apps and ~1000x off for TS apps. The repo's own fixture uses the Python convention (`str((base_ms + 800) / 1000)` in `tests/integration/conftest.py`), which is why tests never caught it.

## The fix

`started_at_epoch_ms` is always ms, and that disambiguates the unit without guessing at magnitudes: a seconds-valued wakeup read as ms lands ~1000x *before* the step started, so it yields a negative duration. Keep whichever interpretations put the wakeup at-or-after the start, then take the smaller — the wrong one is always the wildly inflated one.

<img src="https://raw.githubusercontent.com/dh94/dbos-argus/pr-assets/slash-in-workflow-id/assets/sleep-after.png" width="900" alt="After: the same two sleep steps rendering as 4s and 14d" />

## Tests

`packages/server/tests/test_sleep_duration.py` — 9 cases: both SDK conventions (including an integral-second wakeup, which is the case a naive magnitude check would misread), a 0s sleep, a wakeup before the start, and the existing None paths. The TS case is the regression guard.

## Verification

- `pnpm run lint` clean; `uv run pytest packages/server/tests` 120 passed, 1 skipped
- Against a real DBOS Postgres database written by `@dbos-inc/dbos-sdk@4.23.6`, feeding the actual stored rows through the function:

```
raw=1786361236817  before=56550y  after=14.0d
raw=1785150339204  before=56511y  after=8.0s
raw=1785150330578  before=56511y  after=4.0s
```

- Screenshots are from a scratch SQLite DB seeded with TS-convention (ms) wakeup values. "Before" is `dbos-argus@0.0.33` from PyPI, "after" is this branch, same DB.

## Notes

- Independent of #18 — different function, no overlap beyond both touching `main.py`. Based on current `main`.
- Ambiguity is bounded: a Python-convention wakeup would have to be ~31,000 years in the future before it could be mistaken for a ms value.
- The other rendering oddity I mentioned in #18 (an in-flight workflow showing `DURATION 0ms`) is untouched here — happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqRN2NJ388RqFfGwfoTBR3
