### PR TITLE
Timeline view for workflow details

### DIFF
--- a/.replit
+++ b/.replit
@@ -16,10 +16,10 @@ outputType = "webview"
 [[workflows.workflow.tasks]]
 task = "shell.exec"
 args = "pnpm install && uv sync && pnpm demo"
-waitForPort = 5000
+waitForPort = 4517
 
 [[ports]]
-localPort = 5000
+localPort = 4517
 externalPort = 80
 
 [[ports]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Timeline view on the workflow detail page. A Graph / Timeline toggle (also
+  a `?view=timeline` URL param) switches the canvas to a waterfall trace:
+  one row per step, grouped under each workflow in the family, with bars on
+  a shared time axis built from the step timestamps the detail endpoint
+  already ships. Child workflows interleave at their spawn call site with a
+  dashed queued lead-in, waits (sleep / recv / getEvent / getResult) render
+  as dashed outlines, setEvent / send as instant ticks, and running work
+  extends to a live "now" marker. Long waits are compressed by default —
+  clamped to about one median step's width under a hatched break band, with
+  a "Compress waits / True scale" toggle; spans covered by an executing step
+  are never compressed. Clicking a row drives the same selection and details
+  pane as the graph, and the chosen view persists per browser.
+
 ## [0.0.35] - 2026-07-28
 
 > **Tested against DBOS 2.27.0.** See `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one row per step, grouped under each workflow in the family, with bars on
   a shared time axis built from the step timestamps the detail endpoint
   already ships. Child workflows interleave at their spawn call site with a
-  dashed queued lead-in, waits (sleep / recv / getEvent / getResult) render
-  as dashed outlines, setEvent / send as instant ticks, and running work
-  extends to a live "now" marker. Long waits are compressed by default —
+  dashed queued lead-in (spawn ops that recorded an error or payload keep
+  their own selectable row), waits (sleep / recv / getEvent / getResult)
+  render as dashed outlines, setEvent / send as instant ticks, and running
+  work extends to a live "now" marker. Long waits are compressed by default —
   clamped to about one median step's width under a hatched break band, with
   a "Compress waits / True scale" toggle; spans covered by an executing step
   are never compressed. Clicking a row drives the same selection and details
   pane as the graph, and the chosen view persists per browser.
+- Realtime `snapshot` / `update` / `pong` messages now carry `server_time_ms`
+  (server wall clock at enqueue). The console uses it to correct for client
+  clock skew when positioning the timeline's live edge; older servers that
+  omit the field fall back to the client clock unchanged.
 
 ## [0.0.35] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Console dev server moved from port 5000 to 4517 (Vite, Playwright, the
   Replit workflow, and docs). Port 5000 is grabbed by macOS AirPlay Receiver
   and commonly by other dev tools; 4517 is unassigned and unclaimed.
+- The workflow detail pane now slides open and closed (200ms ease-in-out)
+  instead of snapping, and its collapse/expand button keeps the exact same
+  screen position in both states. The pane header is tighter: content hugs
+  the card's top edge with the toggle inset 4px from the corner.
 
 ## [0.0.35] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clock skew when positioning the timeline's live edge; older servers that
   omit the field fall back to the client clock unchanged.
 
+### Changed
+- Console dev server moved from port 5000 to 4517 (Vite, Playwright, the
+  Replit workflow, and docs). Port 5000 is grabbed by macOS AirPlay Receiver
+  and commonly by other dev tools; 4517 is unassigned and unclaimed.
+
 ## [0.0.35] - 2026-07-28
 
 > **Tested against DBOS 2.27.0.** See `tested_dbos_version` in `GET /version` and `dbos-argus --version`. Argus tracks the latest DBOS schema and does not aim for backward compatibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The root scripts run the same commands CI runs: `pnpm -r run <task>` for the JS 
 Targeted tasks:
 
 ```bash
-pnpm --filter console dev              # SvelteKit dev on :5000
+pnpm --filter console dev              # SvelteKit dev on :4517
 pnpm dev:server                        # FastAPI backend on :8090 (uvicorn --reload)
 uv run pytest packages/server/tests    # all server tests
 uv run ruff check packages/server      # python lint
@@ -61,7 +61,7 @@ Endpoints when up (single port):
 - API healthz: http://localhost:8090/healthz
 - Postgres: localhost:5432 (user/pass/db = `argus/argus/argus`)
 
-Pure frontend dev (HMR): `pnpm --filter console dev` starts Vite on :5000 and proxies `/healthz`, `/version` to a locally running server on :8090 (set `ARGUS_BACKEND_URL` to override).
+Pure frontend dev (HMR): `pnpm --filter console dev` starts Vite on :4517 (an uncommon port on purpose — 5000 collides with macOS AirPlay) and proxies `/healthz`, `/version` to a locally running server on :8090 (set `ARGUS_BACKEND_URL` to override).
 
 Argus does not own a schema. It reads DBOS Transact's system tables (`dbos.workflow_status`, etc.) from the Postgres DB that the DBOS app also uses. No migrations to run.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Bring up the full dev stack (Postgres + server + console):
 docker compose up
 ```
 
-- Console: http://localhost:5000
+- Console: http://localhost:4517
 - Server healthz: http://localhost:8090/healthz
 - Postgres: localhost:5432 (user `argus`, password `argus`, db `argus`)
 

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev --host 0.0.0.0 --port 5000",
+    "dev": "vite dev --host 0.0.0.0 --port 4517",
     "build": "svelte-kit sync && vite build",
-    "preview": "vite preview --host 0.0.0.0 --port 5000",
+    "preview": "vite preview --host 0.0.0.0 --port 4517",
     "lint": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --threshold warning",
     "test": "vitest run",
     "test:e2e": "playwright test",

--- a/apps/console/playwright.config.ts
+++ b/apps/console/playwright.config.ts
@@ -4,11 +4,11 @@ export default defineConfig({
   testDir: "./e2e",
   webServer: {
     command: "pnpm run build && pnpm run start",
-    port: 5000,
+    port: 4517,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
   use: {
-    baseURL: "http://localhost:5000",
+    baseURL: "http://localhost:4517",
   },
 });

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -404,7 +404,7 @@
 </script>
 
 <aside class="bg-card flex h-full min-h-0 w-full flex-col overflow-hidden">
-  <div class="flex min-h-10 items-center gap-2 px-4">
+  <div class="flex min-h-8 items-center gap-2 pl-4 pr-1">
     <span class="text-muted-foreground truncate text-xs font-medium tracking-wide uppercase">
       {heading?.resultLabel ?? "Result"}
     </span>

--- a/apps/console/src/lib/components/WorkflowTimeline.svelte
+++ b/apps/console/src/lib/components/WorkflowTimeline.svelte
@@ -13,6 +13,7 @@
     type TimelineRow,
   } from "$lib/timeline";
   import { statusDotClass } from "$lib/workflow-tree";
+  import { realtimeClient } from "$lib/realtime";
 
   let {
     family,
@@ -29,7 +30,10 @@
   } = $props();
 
   let compress = $state(true);
-  let now = $state(Date.now());
+  // Skew-corrected "now": server clock per the realtime connection, not the
+  // client's Date.now() — bars extending to the live edge are positioned
+  // against server-recorded timestamps. (Issue #23.)
+  let now = $state(realtimeClient.serverNow());
   let trackWidth = $state(0);
 
   const anyActive = $derived(
@@ -40,7 +44,7 @@
 
   $effect(() => {
     if (!anyActive) return;
-    const id = setInterval(() => (now = Date.now()), 1000);
+    const id = setInterval(() => (now = realtimeClient.serverNow()), 1000);
     return () => clearInterval(id);
   });
 
@@ -242,11 +246,21 @@
     return prettyMs(ms, { unitCount: 2, secondsDecimalDigits: ms < 10_000 ? 1 : 0 });
   }
 
+  const rowIds = $derived(new Set(rowViews.map((v) => v.selectionId)));
+
   const selectedId = $derived.by(() => {
     if (!selection) return null;
-    return selection.kind === "workflow"
-      ? `wf:${selection.workflow.workflow_id}`
-      : `step:${selection.step.workflow_id}:${selection.step.function_id}`;
+    if (selection.kind === "workflow") return `wf:${selection.workflow.workflow_id}`;
+    const id = `step:${selection.step.workflow_id}:${selection.step.function_id}`;
+    if (rowIds.has(id)) return id;
+    // A spawn step selected in Graph view may have no timeline row (ordinary
+    // spawns collapse into the child's header) — highlight the child instead
+    // so the highlight and the details pane never disagree.
+    if (selection.step.child_workflow_id) {
+      const childId = `wf:${selection.step.child_workflow_id}`;
+      if (rowIds.has(childId)) return childId;
+    }
+    return id;
   });
 
   // Clicking the already-selected row deselects (the timeline has no empty
@@ -286,6 +300,12 @@
     }
     if (s.function_name.startsWith("DBOS."))
       return s.function_name.slice("DBOS.".length);
+    if (s.child_workflow_id) {
+      // A spawn op rendered as its own row (errored/payload-carrying spawns,
+      // or spawns of out-of-family children) — mirror StepNode's "→ name".
+      const spawned = nameByWorkflowId.get(s.child_workflow_id);
+      return `→ ${spawned ?? s.function_name}`;
+    }
     return s.function_name;
   }
 
@@ -314,8 +334,9 @@
   {#if scale?.wouldCompress}
     <!-- right-14 clears the details pane's floating expand button (top-3
          right-3, 32px wide) when the pane is collapsed. -->
+    <!-- z-20: must paint above the sticky axis header (z-10, opaque). -->
     <ToggleGroup.Root
-      class="bg-card shadow-surface absolute top-3 right-14 z-10 rounded-lg"
+      class="bg-card shadow-surface absolute top-3 right-14 z-20 rounded-lg"
       type="single"
       variant="outline"
       value={compress ? "compressed" : "linear"}
@@ -328,36 +349,44 @@
     </ToggleGroup.Root>
   {/if}
 
-  <!-- pt-12 keeps the axis clear of the page's floating Graph | Timeline
-       toggle, which overlays the (empty) label-column corner. -->
-  <div class="grid flex-none grid-cols-[280px_minmax(0,1fr)] pt-12 pr-6 pb-1">
-    <div></div>
-    <div class="relative h-5" bind:clientWidth={trackWidth}>
-      {#each ticks as tick (tick.x)}
-        <span
-          class="text-muted-foreground absolute top-0 font-mono text-[10px] whitespace-nowrap {tick.x >
-          0
-            ? '-translate-x-1/2'
-            : ''}"
-          style="left: {pct(tick.x)}"
-        >
-          {formatOffset(tick.offsetMs)}
-        </span>
-      {/each}
-      {#each breaks as brk (brk.x0)}
-        <span
-          class="text-muted-foreground absolute top-0 -translate-x-1/2 font-mono text-[10px]"
-          style="left: {pct((brk.x0 + brk.x1) / 2)}"
-          title="{prettyMs(brk.t1 - brk.t0)} compressed"
-        >
-          ⫽
-        </span>
-      {/each}
-    </div>
-  </div>
-
   <div class="min-h-0 flex-1 overflow-y-auto">
-    <div class="relative min-h-full pb-6">
+    <!-- The axis lives *inside* the scroll container (sticky) so its track
+         and the rows' tracks share one coordinate space — measured outside,
+         a layout scrollbar would make the body ~15px narrower and drift
+         every tick label off its gridline. pt-12 keeps it clear of the
+         page's floating Graph | Timeline toggle, which overlays the (empty)
+         label-column corner. -->
+    <div
+      class="bg-background sticky top-0 z-10 grid grid-cols-[280px_minmax(0,1fr)] pt-12 pr-6 pb-1"
+    >
+      <div></div>
+      <div class="relative h-5" bind:clientWidth={trackWidth}>
+        {#each ticks as tick (tick.x)}
+          <span
+            class="text-muted-foreground absolute top-0 font-mono text-[10px] whitespace-nowrap {tick.x >
+            0
+              ? '-translate-x-1/2'
+              : ''}"
+            style="left: {pct(tick.x)}"
+          >
+            {formatOffset(tick.offsetMs)}
+          </span>
+        {/each}
+        {#each breaks as brk (brk.x0)}
+          {#if brk.x1 - brk.x0 >= 0.025}
+            <span
+              class="text-muted-foreground absolute top-0 -translate-x-1/2 font-mono text-[10px]"
+              style="left: {pct((brk.x0 + brk.x1) / 2)}"
+              title="{prettyMs(brk.t1 - brk.t0)} compressed"
+            >
+              ⫽
+            </span>
+          {/if}
+        {/each}
+      </div>
+    </div>
+
+    <div class="relative pb-6">
       {#if scale}
         <div
           aria-hidden="true"
@@ -380,7 +409,10 @@
             {/each}
           </div>
         </div>
-      {:else}
+      {:else if steps.length > 0 && !steps.some((s) => s.started_at)}
+        <!-- Only claim "old database" when timing is genuinely absent. A
+             degenerate scale (e.g. a stepless workflow with zero duration)
+             just renders rows without an axis, no banner. -->
         <p class="text-muted-foreground px-4 py-2 text-xs">
           No step timing recorded — this database predates DBOS's step timestamps.
         </p>

--- a/apps/console/src/lib/components/WorkflowTimeline.svelte
+++ b/apps/console/src/lib/components/WorkflowTimeline.svelte
@@ -1,0 +1,472 @@
+<script lang="ts">
+  import { Workflow as WorkflowIcon, Zap } from "@lucide/svelte";
+  import prettyMs from "pretty-ms";
+  import * as ToggleGroup from "$lib/components/ui/toggle-group";
+  import type { FamilyWorkflow, FlowSelection, Step } from "./WorkflowFlow.svelte";
+  import {
+    buildTimeScale,
+    buildTimelineRows,
+    scaleTicks,
+    stepSpan,
+    workflowSpan,
+    type Span,
+    type TimelineRow,
+  } from "$lib/timeline";
+  import { statusDotClass } from "$lib/workflow-tree";
+
+  let {
+    family,
+    steps,
+    currentId,
+    selection = null,
+    onSelect,
+  }: {
+    family: FamilyWorkflow[];
+    steps: Step[];
+    currentId: string;
+    selection?: FlowSelection;
+    onSelect?: (sel: FlowSelection) => void;
+  } = $props();
+
+  let compress = $state(true);
+  let now = $state(Date.now());
+  let trackWidth = $state(0);
+
+  const anyActive = $derived(
+    family.some(
+      (w) => w.status === "PENDING" || w.status === "ENQUEUED" || w.status === "DELAYED",
+    ) || steps.some((s) => s.started_at && !s.completed_at),
+  );
+
+  $effect(() => {
+    if (!anyActive) return;
+    const id = setInterval(() => (now = Date.now()), 1000);
+    return () => clearInterval(id);
+  });
+
+  const rows = $derived(buildTimelineRows(family, steps));
+  const nameByWorkflowId = $derived(new Map(family.map((w) => [w.workflow_id, w.name ?? null])));
+
+  // A wait parks the workflow (or blocks on another one); an instant op is a
+  // point-in-time marker. Everything else is a regular executing step.
+  function isWaitStep(s: Step): boolean {
+    return (
+      s.function_name === "DBOS.sleep" ||
+      s.function_name === "DBOS.recv" ||
+      s.function_name === "DBOS.getEvent" ||
+      s.function_name === "DBOS.getResult"
+    );
+  }
+
+  function isInstantStep(s: Step): boolean {
+    return s.function_name === "DBOS.setEvent" || s.function_name === "DBOS.send";
+  }
+
+  type RowView = {
+    row: TimelineRow;
+    selectionId: string;
+    // Bars in track coordinates; `queued` renders dashed before `bar`.
+    bar: Span | null;
+    queued: Span | null;
+    barCls: string;
+    isInstant: boolean;
+    tooltip: string;
+    durationLabel: string | null;
+  };
+
+  function fmtClock(t: number): string {
+    return new Date(t).toLocaleString();
+  }
+
+  function tooltipFor(name: string, span: Span | null, extra: string | null): string {
+    if (!span) return name;
+    const range = `${fmtClock(span.start)} → ${span.openEnded ? "now" : fmtClock(span.end)}`;
+    const dur = prettyMs(Math.max(0, span.end - span.start));
+    return `${name}\n${range}\n${dur}${extra ? `\n${extra}` : ""}`;
+  }
+
+  function workflowBarCls(status: string | null): string {
+    const s = (status ?? "").toUpperCase();
+    if (s === "ERROR" || s === "MAX_RECOVERY_ATTEMPTS_EXCEEDED")
+      return "border border-status-error/70 bg-status-error/20";
+    if (s === "CANCELLED") return "border border-status-warning/70 bg-status-warning/20";
+    if (s === "PENDING" || s === "DELAYED")
+      return "border border-status-running/70 bg-status-running/20 animate-pulse";
+    if (s === "ENQUEUED") return "border border-dashed border-muted-foreground/60";
+    return "border border-workflow-accent/70 bg-workflow-accent/20";
+  }
+
+  function stepBarCls(s: Step, span: Span | null): string {
+    if (isInstantStep(s)) return "bg-status-warning dark:bg-highlight";
+    if (isWaitStep(s)) {
+      return span?.openEnded
+        ? "border border-dashed border-status-running/80 animate-pulse"
+        : "border border-dashed border-muted-foreground/50";
+    }
+    if (s.has_error) return "border border-status-error/70 bg-status-error/30";
+    if (span?.openEnded) return "border border-status-running/70 bg-status-running/25 animate-pulse";
+    return "border border-status-success/70 bg-status-success/25";
+  }
+
+  const rowViews: RowView[] = $derived.by(() => {
+    const nowMs = now;
+    // Per-workflow envelope over its steps. A recovered workflow's
+    // started_at_epoch_ms is reset to the latest dequeue, which can land
+    // *after* steps recorded by earlier attempts — the container bar must
+    // still cover them.
+    const envelopes = new Map<string, { min: number; max: number }>();
+    for (const s of steps) {
+      const span = stepSpan(s, nowMs);
+      if (!span) continue;
+      const env = envelopes.get(s.workflow_id);
+      if (!env) {
+        envelopes.set(s.workflow_id, { min: span.start, max: span.end });
+      } else {
+        env.min = Math.min(env.min, span.start);
+        env.max = Math.max(env.max, span.end);
+      }
+    }
+    return rows.map((r): RowView => {
+      if (r.kind === "workflow") {
+        const w = r.workflow as FamilyWorkflow;
+        let span = workflowSpan(r.workflow, nowMs);
+        const env = envelopes.get(w.workflow_id);
+        if (span && env) {
+          span = {
+            start: Math.min(span.start, env.min),
+            end: Math.max(span.end, env.max),
+            openEnded: span.openEnded,
+          };
+        }
+        // Dashed lead-in from the moment the parent enqueued the child to the
+        // child's own run start. Only meaningful when the queue actually held
+        // it back; sub-250ms queue time is noise at this scale.
+        let queued: Span | null = null;
+        const spawnStartRaw = r.spawnStep?.started_at;
+        if (span && spawnStartRaw) {
+          const spawnStart = Date.parse(spawnStartRaw);
+          if (!Number.isNaN(spawnStart) && span.start - spawnStart > 250) {
+            queued = { start: spawnStart, end: span.start, openEnded: false };
+          }
+        }
+        const name = w.name ?? w.workflow_id;
+        return {
+          row: r,
+          selectionId: `wf:${w.workflow_id}`,
+          bar: span,
+          queued,
+          barCls: workflowBarCls(w.status),
+          isInstant: false,
+          tooltip: tooltipFor(name, span, w.status),
+          durationLabel:
+            w.status === "ENQUEUED"
+              ? "queued"
+              : span
+                ? prettyMs(Math.max(0, span.end - span.start), { compact: true })
+                : null,
+        };
+      }
+      const s = r.step as Step;
+      const span = stepSpan(r.step, nowMs);
+      const displayMs =
+        s.sleep_requested_ms != null
+          ? s.sleep_requested_ms
+          : span
+            ? span.end - span.start
+            : null;
+      return {
+        row: r,
+        selectionId: `step:${s.workflow_id}:${s.function_id}`,
+        bar: span,
+        queued: null,
+        barCls: stepBarCls(s, span),
+        isInstant: isInstantStep(s),
+        tooltip: tooltipFor(
+          s.function_name,
+          span,
+          s.sleep_requested_ms != null
+            ? `${prettyMs(s.sleep_requested_ms)} requested`
+            : null,
+        ),
+        durationLabel:
+          displayMs !== null && !isInstantStep(s)
+            ? prettyMs(Math.max(0, displayMs), { compact: true })
+            : null,
+      };
+    });
+  });
+
+  const scale = $derived.by(() => {
+    const times: number[] = [];
+    const protect: Array<{ start: number; end: number }> = [];
+    for (const v of rowViews) {
+      if (v.bar) times.push(v.bar.start, v.bar.end);
+      if (v.queued) times.push(v.queued.start);
+      // Executing steps anchor the compression cap and shield their span
+      // from clamping; workflow containers and waits don't count as work.
+      if (v.bar && v.row.kind === "step" && !isWaitStep(v.row.step as Step) && !v.isInstant) {
+        protect.push({ start: v.bar.start, end: v.bar.end });
+      }
+    }
+    return buildTimeScale(times, compress, protect);
+  });
+
+  const tickCount = $derived(
+    trackWidth > 0 ? Math.max(2, Math.min(12, Math.floor(trackWidth / 110))) : 6,
+  );
+  const ticks = $derived(scale ? scaleTicks(scale, tickCount) : []);
+  const breaks = $derived(scale ? scale.segments.filter((s) => s.compressed) : []);
+  const nowX = $derived(anyActive && scale ? scale.toX(now) : null);
+
+  function pct(x: number): string {
+    return `${(x * 100).toFixed(4)}%`;
+  }
+
+  function barGeom(span: Span): string {
+    if (!scale) return "";
+    const left = scale.toX(span.start);
+    const right = scale.toX(span.end);
+    return `left: ${pct(left)}; width: ${pct(Math.max(0, right - left))};`;
+  }
+
+  function formatOffset(ms: number): string {
+    if (ms <= 0) return "0s";
+    return prettyMs(ms, { unitCount: 2, secondsDecimalDigits: ms < 10_000 ? 1 : 0 });
+  }
+
+  const selectedId = $derived.by(() => {
+    if (!selection) return null;
+    return selection.kind === "workflow"
+      ? `wf:${selection.workflow.workflow_id}`
+      : `step:${selection.step.workflow_id}:${selection.step.function_id}`;
+  });
+
+  // Clicking the already-selected row deselects (the timeline has no empty
+  // canvas to click, unlike the graph pane).
+  function select(v: RowView) {
+    if (!onSelect) return;
+    if (v.selectionId === selectedId) {
+      onSelect(null);
+      return;
+    }
+    const row = v.row;
+    if (row.kind === "workflow") {
+      const wfId = row.workflow.workflow_id;
+      const wf = family.find((w) => w.workflow_id === wfId);
+      if (wf) onSelect({ kind: "workflow", workflow: wf });
+    } else {
+      const { workflow_id, function_id } = row.step;
+      const step = steps.find(
+        (s) => s.workflow_id === workflow_id && s.function_id === function_id,
+      );
+      if (step) onSelect({ kind: "step", step });
+    }
+  }
+
+  function stepName(s: Step): string {
+    if (s.function_name === "DBOS.setEvent")
+      return s.event_key ? `set → "${s.event_key}"` : "set → event";
+    if (s.function_name === "DBOS.getEvent")
+      return s.event_key ? `get ← "${s.event_key}"` : "get ← event";
+    if (s.function_name === "DBOS.recv")
+      return s.event_key ? `recv ← "${s.event_key}"` : "recv";
+    if (s.function_name === "DBOS.getResult") {
+      const awaited = s.child_workflow_id
+        ? nameByWorkflowId.get(s.child_workflow_id)
+        : null;
+      return `← ${awaited ?? "getResult"}`;
+    }
+    if (s.function_name.startsWith("DBOS."))
+      return s.function_name.slice("DBOS.".length);
+    return s.function_name;
+  }
+
+  function stepNameCls(s: Step): string {
+    if (isInstantStep(s) || s.function_name === "DBOS.getEvent" || s.function_name === "DBOS.recv")
+      return "text-highlight-foreground dark:text-highlight";
+    if (s.function_name === "DBOS.getResult") return "text-workflow-accent";
+    if (s.function_name.startsWith("DBOS.")) return "text-muted-foreground";
+    if (s.child_workflow_id) return "text-workflow-accent";
+    return "text-foreground";
+  }
+
+  function stepDotCls(s: Step): string {
+    if (s.function_name.startsWith("DBOS.")) return "bg-muted-foreground/40";
+    if (s.has_error) return "bg-status-error";
+    if (s.started_at && !s.completed_at) return "bg-status-running animate-pulse";
+    if (s.completed_at) return "bg-status-success";
+    return "bg-muted-foreground/40";
+  }
+
+  const BREAK_STRIPES =
+    "repeating-linear-gradient(135deg, transparent 0 5px, color-mix(in oklab, var(--color-muted-foreground) 20%, transparent) 5px 7px)";
+</script>
+
+<div class="bg-background relative flex h-full min-h-0 flex-col">
+  {#if scale?.wouldCompress}
+    <!-- right-14 clears the details pane's floating expand button (top-3
+         right-3, 32px wide) when the pane is collapsed. -->
+    <ToggleGroup.Root
+      class="bg-card shadow-surface absolute top-3 right-14 z-10 rounded-lg"
+      type="single"
+      variant="outline"
+      value={compress ? "compressed" : "linear"}
+      onValueChange={(v) => {
+        if (v) compress = v === "compressed";
+      }}
+    >
+      <ToggleGroup.Item value="compressed" class="h-7 px-2.5">Compress waits</ToggleGroup.Item>
+      <ToggleGroup.Item value="linear" class="h-7 px-2.5">True scale</ToggleGroup.Item>
+    </ToggleGroup.Root>
+  {/if}
+
+  <!-- pt-12 keeps the axis clear of the page's floating Graph | Timeline
+       toggle, which overlays the (empty) label-column corner. -->
+  <div class="grid flex-none grid-cols-[280px_minmax(0,1fr)] pt-12 pr-6 pb-1">
+    <div></div>
+    <div class="relative h-5" bind:clientWidth={trackWidth}>
+      {#each ticks as tick (tick.x)}
+        <span
+          class="text-muted-foreground absolute top-0 font-mono text-[10px] whitespace-nowrap {tick.x >
+          0
+            ? '-translate-x-1/2'
+            : ''}"
+          style="left: {pct(tick.x)}"
+        >
+          {formatOffset(tick.offsetMs)}
+        </span>
+      {/each}
+      {#each breaks as brk (brk.x0)}
+        <span
+          class="text-muted-foreground absolute top-0 -translate-x-1/2 font-mono text-[10px]"
+          style="left: {pct((brk.x0 + brk.x1) / 2)}"
+          title="{prettyMs(brk.t1 - brk.t0)} compressed"
+        >
+          ⫽
+        </span>
+      {/each}
+    </div>
+  </div>
+
+  <div class="min-h-0 flex-1 overflow-y-auto">
+    <div class="relative min-h-full pb-6">
+      {#if scale}
+        <div
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-0 grid grid-cols-[280px_minmax(0,1fr)] pr-6"
+        >
+          <div></div>
+          <div class="relative">
+            {#each ticks as tick (tick.x)}
+              {#if tick.x > 0}
+                <div class="bg-border/70 absolute inset-y-0 w-px" style="left: {pct(tick.x)}"></div>
+              {/if}
+            {/each}
+            {#each breaks as brk (brk.x0)}
+              <div
+                class="absolute inset-y-0"
+                style="left: {pct(brk.x0)}; width: {pct(
+                  brk.x1 - brk.x0,
+                )}; background: {BREAK_STRIPES};"
+              ></div>
+            {/each}
+          </div>
+        </div>
+      {:else}
+        <p class="text-muted-foreground px-4 py-2 text-xs">
+          No step timing recorded — this database predates DBOS's step timestamps.
+        </p>
+      {/if}
+
+      {#each rowViews as v (v.selectionId)}
+        {@const isWorkflow = v.row.kind === "workflow"}
+        {@const selected = v.selectionId === selectedId}
+        <button
+          type="button"
+          class="grid w-full cursor-pointer grid-cols-[280px_minmax(0,1fr)] pr-6 text-left
+            {isWorkflow ? 'h-8' : 'h-7'}
+            {selected
+            ? 'bg-primary/8 shadow-[inset_2px_0_0_var(--color-primary)]'
+            : 'hover:bg-muted/60'}"
+          title={v.tooltip}
+          aria-pressed={selected}
+          onclick={() => select(v)}
+        >
+          <span
+            class="flex min-w-0 items-center gap-2"
+            style="padding-left: {12 + v.row.depth * 14}px"
+          >
+            {#if v.row.kind === "workflow"}
+              {@const w = v.row.workflow}
+              <WorkflowIcon class="text-workflow-accent h-3 w-3 flex-none" aria-hidden="true" />
+              <span
+                class="truncate font-mono text-xs font-medium
+                  {w.workflow_id === currentId ? 'text-workflow-accent' : 'text-foreground'}"
+                title={w.workflow_id}
+              >
+                {w.name ?? w.workflow_id}
+              </span>
+              <span
+                class="h-2 w-2 flex-none rounded-full {statusDotClass(w.status)}"
+                aria-hidden="true"
+              ></span>
+            {:else}
+              {@const s = v.row.step as Step}
+              {#if isInstantStep(s)}
+                <Zap
+                  class="fill-status-warning text-status-warning dark:fill-highlight dark:text-highlight h-3 w-3 flex-none"
+                  aria-hidden="true"
+                />
+              {:else}
+                <span
+                  class="h-2 w-2 flex-none rounded-full {stepDotCls(s)}"
+                  aria-hidden="true"
+                ></span>
+              {/if}
+              <span class="text-muted-foreground flex-none font-mono text-[10px]">
+                #{s.function_id}
+              </span>
+              <span class="truncate font-mono text-xs {stepNameCls(s)}">{stepName(s)}</span>
+            {/if}
+            {#if v.durationLabel}
+              <span class="text-muted-foreground ml-auto flex-none pr-3 font-mono text-[10px]">
+                {v.durationLabel}
+              </span>
+            {/if}
+          </span>
+          <span class="relative block h-full">
+            {#if scale && v.queued}
+              <span
+                class="border-muted-foreground/60 absolute top-1/2 h-3 min-w-[3px] -translate-y-1/2 rounded-[3px] border border-dashed"
+                style={barGeom(v.queued)}
+                aria-hidden="true"
+              ></span>
+            {/if}
+            {#if scale && v.bar}
+              <span
+                class="absolute top-1/2 min-w-[3px] -translate-y-1/2 rounded-[3px]
+                  {isWorkflow ? 'h-4' : 'h-3'}
+                  {v.bar.openEnded ? 'rounded-r-none' : ''}
+                  {v.barCls}"
+                style={barGeom(v.bar)}
+                aria-hidden="true"
+              ></span>
+            {/if}
+          </span>
+        </button>
+      {/each}
+
+      {#if nowX !== null}
+        <div
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-0 grid grid-cols-[280px_minmax(0,1fr)] pr-6"
+        >
+          <div></div>
+          <div class="relative">
+            <div class="bg-status-running/80 absolute inset-y-0 w-px" style="left: {pct(nowX)}"></div>
+          </div>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/apps/console/src/lib/components/WorkflowTimeline.svelte
+++ b/apps/console/src/lib/components/WorkflowTimeline.svelte
@@ -110,13 +110,21 @@
 
   const rowViews: RowView[] = $derived.by(() => {
     const nowMs = now;
+    // Terminal completion per workflow: clamps inferred step extents (sleep
+    // wake projections, open-ended bars) so nothing renders as running past
+    // the owning workflow's death. Null while the workflow is still live.
+    const terminalEnds = new Map<string, number | null>();
+    for (const w of family) {
+      const ws = workflowSpan(w, nowMs);
+      terminalEnds.set(w.workflow_id, ws && !ws.openEnded ? ws.end : null);
+    }
     // Per-workflow envelope over its steps. A recovered workflow's
     // started_at_epoch_ms is reset to the latest dequeue, which can land
     // *after* steps recorded by earlier attempts — the container bar must
     // still cover them.
     const envelopes = new Map<string, { min: number; max: number }>();
     for (const s of steps) {
-      const span = stepSpan(s, nowMs);
+      const span = stepSpan(s, nowMs, terminalEnds.get(s.workflow_id) ?? null);
       if (!span) continue;
       const env = envelopes.get(s.workflow_id);
       if (!env) {
@@ -167,7 +175,7 @@
         };
       }
       const s = r.step as Step;
-      const span = stepSpan(r.step, nowMs);
+      const span = stepSpan(r.step, nowMs, terminalEnds.get(s.workflow_id) ?? null);
       const displayMs =
         s.sleep_requested_ms != null
           ? s.sleep_requested_ms

--- a/apps/console/src/lib/realtime/client.svelte.ts
+++ b/apps/console/src/lib/realtime/client.svelte.ts
@@ -73,6 +73,20 @@ export class RealtimeClient {
   // Reactive state — read these from components / .svelte.ts wrappers.
   connectionStatus = $state<ConnectionStatus>("closed");
   lastError = $state<string | null>(null);
+  /**
+   * server clock − client clock, from the latest `server_time_ms` seen on
+   * any snapshot/update/pong. The latest sample is used as-is: one-way
+   * delivery latency (ms) is noise next to the wall-clock skew (seconds+)
+   * this corrects for, and smoothing would just delay convergence after a
+   * clock step. 0 until the first stamped message arrives.
+   */
+  clockOffsetMs = $state(0);
+
+  /** Best-known server wall clock — use instead of Date.now() whenever the
+   * value is compared against server-recorded timestamps. */
+  serverNow(): number {
+    return Date.now() + this.clockOffsetMs;
+  }
 
   private readonly subs = new Map<string, InternalSub>();
   private socket: WebSocket | null = null;
@@ -211,15 +225,18 @@ export class RealtimeClient {
       return;
     }
     if (msg.type === "pong") {
+      this.recordServerTime(msg.server_time_ms);
       this.clearPongTimer();
       return;
     }
     if (msg.type === "snapshot") {
+      this.recordServerTime(msg.server_time_ms);
       const sub = this.subs.get(msg.sub_id);
       sub?.handlers.onSnapshot(msg.data, msg);
       return;
     }
     if (msg.type === "update") {
+      this.recordServerTime(msg.server_time_ms);
       const sub = this.subs.get(msg.sub_id);
       sub?.handlers.onUpdate(msg.data, msg);
       return;
@@ -234,6 +251,11 @@ export class RealtimeClient {
       return;
     }
     // ack — ignore by default; useful only for tests.
+  }
+
+  private recordServerTime(serverTimeMs: number | null | undefined): void {
+    if (typeof serverTimeMs !== "number" || !Number.isFinite(serverTimeMs)) return;
+    this.clockOffsetMs = serverTimeMs - Date.now();
   }
 
   private replaySubscriptions(): void {

--- a/apps/console/src/lib/realtime/client.test.ts
+++ b/apps/console/src/lib/realtime/client.test.ts
@@ -110,6 +110,39 @@ describe("RealtimeClient", () => {
     client.close();
   });
 
+  it("tracks clock offset from server_time_ms and exposes serverNow()", () => {
+    const { client, sockets } = makeClient();
+    client.subscribe("stats", undefined, { onSnapshot: vi.fn(), onUpdate: vi.fn() });
+    const ws = sockets[0];
+    ws.triggerOpen();
+    const subId = (ws.sent[0] as { sub_id: string }).sub_id;
+
+    // No stamped message yet — serverNow() is plain client time.
+    expect(client.clockOffsetMs).toBe(0);
+
+    const skewed = Date.now() + 30_000; // server 30s ahead
+    ws.deliver({
+      type: "snapshot",
+      sub_id: subId,
+      channel: "stats",
+      data: {},
+      server_time_ms: skewed,
+    });
+    // Delivery is synchronous in the fake, so the offset is ~30s exactly.
+    expect(client.clockOffsetMs).toBeGreaterThan(29_000);
+    expect(client.serverNow() - Date.now()).toBeGreaterThan(29_000);
+
+    // Pongs refresh the offset too (quiet connections), and an unstamped
+    // message (older server) leaves it untouched.
+    ws.deliver({ type: "pong", server_time_ms: Date.now() - 10_000 });
+    expect(client.clockOffsetMs).toBeLessThan(-9_000);
+    const before = client.clockOffsetMs;
+    ws.deliver({ type: "update", sub_id: subId, channel: "stats", data: { total: 3 } });
+    expect(client.clockOffsetMs).toBe(before);
+
+    client.close();
+  });
+
   it("queues subscribe when called before socket opens, then flushes on open", () => {
     const { client, sockets } = makeClient();
     client.subscribe("stats", undefined, { onSnapshot: vi.fn(), onUpdate: vi.fn() });

--- a/apps/console/src/lib/realtime/protocol.ts
+++ b/apps/console/src/lib/realtime/protocol.ts
@@ -37,6 +37,8 @@ export type SnapshotMessage = {
   sub_id: string;
   channel: string;
   data: unknown;
+  /** Server wall clock (epoch ms) at enqueue time — used for skew correction. */
+  server_time_ms?: number | null;
 };
 
 export type UpdateMessage = {
@@ -44,6 +46,7 @@ export type UpdateMessage = {
   sub_id: string;
   channel: string;
   data: unknown;
+  server_time_ms?: number | null;
 };
 
 export type ErrorMessage = {
@@ -53,7 +56,7 @@ export type ErrorMessage = {
   message: string;
 };
 
-export type PongMessage = { type: "pong" };
+export type PongMessage = { type: "pong"; server_time_ms?: number | null };
 
 export type AckMessage = {
   type: "ack";

--- a/apps/console/src/lib/timeline.test.ts
+++ b/apps/console/src/lib/timeline.test.ts
@@ -148,6 +148,51 @@ describe("spans", () => {
     expect(stepSpan(s, now)).toEqual({ start: T0, end: now, openEnded: true });
   });
 
+  it("clamps a sleep's projected wake to the workflow's terminal end", () => {
+    // 1h sleep, workflow cancelled 5s in: the bar must stop at the death,
+    // not run to term.
+    const s = step({
+      workflow_id: "w",
+      function_id: 0,
+      function_name: "DBOS.sleep",
+      completed_at: iso(5),
+      sleep_requested_ms: 3_600_000,
+    });
+    const viewedAt = T0 + 7_200_000;
+    expect(stepSpan(s, viewedAt, T0 + 5000)).toEqual({
+      start: T0,
+      end: T0 + 5000,
+      openEnded: false,
+    });
+    // Viewed while the wake is still in the future: same clamp, and the bar
+    // must not read as "still sleeping" on a dead workflow.
+    expect(stepSpan(s, T0 + 60_000, T0 + 5000)).toEqual({
+      start: T0,
+      end: T0 + 5000,
+      openEnded: false,
+    });
+  });
+
+  it("clamps an open-ended step to the workflow's terminal end", () => {
+    const s = step({ workflow_id: "w", function_id: 0, completed_at: null });
+    expect(stepSpan(s, now, T0 + 2000)).toEqual({
+      start: T0,
+      end: T0 + 2000,
+      openEnded: false,
+    });
+  });
+
+  it("never clamps a recorded completion", () => {
+    // completed_at is a fact; a workflow updated_at that sorts earlier
+    // (clock write order) must not truncate it.
+    const s = step({ workflow_id: "w", function_id: 0, completed_at: iso(3000) });
+    expect(stepSpan(s, now, T0 + 1000)).toEqual({
+      start: T0,
+      end: T0 + 3000,
+      openEnded: false,
+    });
+  });
+
   it("ends a terminal workflow without completed_at at updated_at", () => {
     const w = wf({ workflow_id: "w", completed_at: null, updated_at: iso(2000) });
     expect(workflowSpan(w, now)).toEqual({ start: T0, end: T0 + 2000, openEnded: false });

--- a/apps/console/src/lib/timeline.test.ts
+++ b/apps/console/src/lib/timeline.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTimeScale,
+  buildTimelineRows,
+  scaleTicks,
+  stepSpan,
+  workflowSpan,
+  type TimelineStep,
+  type TimelineWorkflow,
+} from "./timeline";
+
+const T0 = Date.parse("2026-01-01T00:00:00Z");
+
+function iso(offsetMs: number): string {
+  return new Date(T0 + offsetMs).toISOString();
+}
+
+function wf(over: Partial<TimelineWorkflow> & { workflow_id: string }): TimelineWorkflow {
+  return {
+    parent_workflow_id: null,
+    name: over.workflow_id,
+    status: "SUCCESS",
+    started_at: iso(0),
+    updated_at: iso(1000),
+    completed_at: iso(1000),
+    ...over,
+  };
+}
+
+function step(over: Partial<TimelineStep> & { workflow_id: string; function_id: number }): TimelineStep {
+  return {
+    function_name: "do_thing",
+    has_error: false,
+    child_workflow_id: null,
+    started_at: iso(0),
+    completed_at: iso(100),
+    event_key: null,
+    sleep_requested_ms: null,
+    ...over,
+  };
+}
+
+describe("buildTimelineRows", () => {
+  it("interleaves a spawned child subtree at its call site", () => {
+    const family = [
+      wf({ workflow_id: "root" }),
+      wf({ workflow_id: "child", parent_workflow_id: "root" }),
+    ];
+    const steps = [
+      step({ workflow_id: "root", function_id: 0, function_name: "before" }),
+      step({
+        workflow_id: "root",
+        function_id: 1,
+        function_name: "child_wf",
+        child_workflow_id: "child",
+      }),
+      step({ workflow_id: "root", function_id: 2, function_name: "after" }),
+      step({ workflow_id: "child", function_id: 0, function_name: "inner" }),
+    ];
+    const rows = buildTimelineRows(family, steps);
+    const labels = rows.map((r) =>
+      r.kind === "workflow" ? `wf:${r.workflow.workflow_id}` : `step:${r.step.function_name}`,
+    );
+    expect(labels).toEqual([
+      "wf:root",
+      "step:before",
+      "wf:child",
+      "step:inner",
+      "step:after",
+    ]);
+    const childRow = rows[2];
+    expect(childRow.kind === "workflow" && childRow.spawnStep?.function_id).toBe(1);
+    expect(childRow.kind === "workflow" && childRow.depth).toBe(1);
+  });
+
+  it("keeps DBOS.getResult rows as plain steps even with a child id", () => {
+    const family = [
+      wf({ workflow_id: "root" }),
+      wf({ workflow_id: "child", parent_workflow_id: "root" }),
+    ];
+    const steps = [
+      step({
+        workflow_id: "root",
+        function_id: 0,
+        function_name: "child_wf",
+        child_workflow_id: "child",
+      }),
+      step({
+        workflow_id: "root",
+        function_id: 1,
+        function_name: "DBOS.getResult",
+        child_workflow_id: "child",
+      }),
+    ];
+    const rows = buildTimelineRows(family, steps);
+    expect(rows.map((r) => r.kind)).toEqual(["workflow", "workflow", "step"]);
+  });
+
+  it("emits unlinked family members instead of dropping them", () => {
+    const family = [
+      wf({ workflow_id: "root" }),
+      wf({ workflow_id: "orphan", parent_workflow_id: "root" }),
+    ];
+    const rows = buildTimelineRows(family, []);
+    expect(rows.map((r) => r.kind === "workflow" && r.workflow.workflow_id)).toEqual([
+      "root",
+      "orphan",
+    ]);
+  });
+});
+
+describe("spans", () => {
+  const now = T0 + 60_000;
+
+  it("uses recorded start/complete for ordinary steps", () => {
+    const s = step({ workflow_id: "w", function_id: 0 });
+    expect(stepSpan(s, now)).toEqual({ start: T0, end: T0 + 100, openEnded: false });
+  });
+
+  it("extends a started-but-uncompleted step to now", () => {
+    const s = step({ workflow_id: "w", function_id: 0, completed_at: null });
+    expect(stepSpan(s, now)).toEqual({ start: T0, end: now, openEnded: true });
+  });
+
+  it("returns null without a start time", () => {
+    expect(stepSpan(step({ workflow_id: "w", function_id: 0, started_at: null }), now)).toBeNull();
+  });
+
+  it("spans a sleep to its wake-up, not its recorded completion", () => {
+    const s = step({
+      workflow_id: "w",
+      function_id: 0,
+      function_name: "DBOS.sleep",
+      completed_at: iso(5), // DBOS records sleeps up-front: completed ≈ started
+      sleep_requested_ms: 30_000,
+    });
+    expect(stepSpan(s, now)).toEqual({ start: T0, end: T0 + 30_000, openEnded: false });
+  });
+
+  it("clamps an in-progress sleep to now", () => {
+    const s = step({
+      workflow_id: "w",
+      function_id: 0,
+      function_name: "DBOS.sleep",
+      completed_at: iso(5),
+      sleep_requested_ms: 600_000,
+    });
+    expect(stepSpan(s, now)).toEqual({ start: T0, end: now, openEnded: true });
+  });
+
+  it("ends a terminal workflow without completed_at at updated_at", () => {
+    const w = wf({ workflow_id: "w", completed_at: null, updated_at: iso(2000) });
+    expect(workflowSpan(w, now)).toEqual({ start: T0, end: T0 + 2000, openEnded: false });
+  });
+
+  it("extends a running workflow to now", () => {
+    const w = wf({ workflow_id: "w", status: "PENDING", completed_at: null });
+    expect(workflowSpan(w, now)).toEqual({ start: T0, end: now, openEnded: true });
+  });
+});
+
+describe("buildTimeScale", () => {
+  it("is linear when gaps are comparable", () => {
+    const scale = buildTimeScale([0, 1000, 2000, 3000, 4000], true)!;
+    expect(scale.wouldCompress).toBe(false);
+    expect(scale.compressionApplied).toBe(false);
+    expect(scale.toX(2000)).toBeCloseTo(0.5);
+    expect(scale.fromX(0.25)).toBeCloseTo(1000);
+  });
+
+  it("clamps a dominant gap when compression is on", () => {
+    // Four 1s gaps and one 100s gap. Linear puts the wait at ~96% of the
+    // width; compressed renders it at the median-gap weight (1s) → 1/5.
+    const times = [0, 1000, 2000, 3000, 4000, 104_000];
+    const compressed = buildTimeScale(times, true)!;
+    expect(compressed.wouldCompress).toBe(true);
+    expect(compressed.compressionApplied).toBe(true);
+    const waitSeg = compressed.segments[compressed.segments.length - 1];
+    expect(waitSeg.compressed).toBe(true);
+    expect(waitSeg.x1 - waitSeg.x0).toBeCloseTo(1 / 5);
+
+    const linear = buildTimeScale(times, false)!;
+    expect(linear.compressionApplied).toBe(false);
+    expect(linear.wouldCompress).toBe(true);
+    const linearWait = linear.segments[linear.segments.length - 1];
+    expect(linearWait.x1 - linearWait.x0).toBeCloseTo(100 / 104);
+  });
+
+  it("round-trips toX/fromX inside uncompressed segments", () => {
+    const scale = buildTimeScale([0, 1000, 2000, 3000, 4000, 104_000], true)!;
+    for (const t of [500, 1500, 3500]) {
+      expect(scale.fromX(scale.toX(t))).toBeCloseTo(t);
+    }
+  });
+
+  it("clamps out-of-range inputs", () => {
+    const scale = buildTimeScale([1000, 2000], false)!;
+    expect(scale.toX(0)).toBe(0);
+    expect(scale.toX(5000)).toBe(1);
+    expect(scale.fromX(-1)).toBe(1000);
+    expect(scale.fromX(2)).toBe(2000);
+  });
+
+  it("never compresses a span covered by an executing step", () => {
+    // Same shape as the dominant-gap case, but the 100s stretch is a real
+    // step's execution, not a wait — it must stay linear and unclamped.
+    const times = [0, 1000, 2000, 3000, 4000, 104_000];
+    const scale = buildTimeScale(times, true, [{ start: 4000, end: 104_000 }])!;
+    expect(scale.wouldCompress).toBe(false);
+    expect(scale.segments.every((s) => !s.compressed)).toBe(true);
+    const seg = scale.segments[scale.segments.length - 1];
+    expect(seg.x1 - seg.x0).toBeCloseTo(100 / 104);
+  });
+
+  it("derives the cap from executing-step durations, not boundary gaps", () => {
+    // Boundaries 1ms apart would give a tiny median gap; the 2s executing
+    // steps push the cap to 20s so the 15s wait survives uncompressed.
+    const times = [0, 1, 2000, 2001, 4000, 19_000];
+    const scale = buildTimeScale(times, true, [
+      { start: 1, end: 2000 },
+      { start: 2001, end: 4000 },
+    ])!;
+    expect(scale.wouldCompress).toBe(false);
+  });
+
+  it("returns null for degenerate inputs", () => {
+    expect(buildTimeScale([], true)).toBeNull();
+    expect(buildTimeScale([1000], true)).toBeNull();
+    expect(buildTimeScale([1000, 1000], true)).toBeNull();
+  });
+});
+
+describe("scaleTicks", () => {
+  it("skips ticks inside compressed segments", () => {
+    const scale = buildTimeScale([0, 1000, 2000, 3000, 4000, 104_000], true)!;
+    const ticks = scaleTicks(scale, 10);
+    // The compressed wait occupies the last 10/14 ≈ 71% of the axis; only
+    // ticks in the leading linear region (plus x=0) survive.
+    expect(ticks.length).toBeGreaterThan(0);
+    expect(ticks[0]).toEqual({ x: 0, offsetMs: 0 });
+    const waitSeg = scale.segments[scale.segments.length - 1];
+    for (const tick of ticks) {
+      expect(tick.x > waitSeg.x0 && tick.x < waitSeg.x1).toBe(false);
+    }
+  });
+
+  it("covers the full axis when linear", () => {
+    const scale = buildTimeScale([0, 10_000], false)!;
+    const ticks = scaleTicks(scale, 5);
+    expect(ticks.map((t) => t.offsetMs)).toEqual([0, 2000, 4000, 6000, 8000]);
+  });
+});

--- a/apps/console/src/lib/timeline.test.ts
+++ b/apps/console/src/lib/timeline.test.ts
@@ -31,6 +31,7 @@ function step(over: Partial<TimelineStep> & { workflow_id: string; function_id: 
   return {
     function_name: "do_thing",
     has_error: false,
+    has_output: false,
     child_workflow_id: null,
     started_at: iso(0),
     completed_at: iso(100),
@@ -96,6 +97,63 @@ describe("buildTimelineRows", () => {
     expect(rows.map((r) => r.kind)).toEqual(["workflow", "workflow", "step"]);
   });
 
+  it("keeps a selectable row for a spawn step with an error or payload", () => {
+    const family = [
+      wf({ workflow_id: "root" }),
+      wf({ workflow_id: "child", parent_workflow_id: "root" }),
+    ];
+    const steps = [
+      step({
+        workflow_id: "root",
+        function_id: 0,
+        function_name: "child_wf",
+        child_workflow_id: "child",
+        has_error: true,
+      }),
+    ];
+    const rows = buildTimelineRows(family, steps);
+    const labels = rows.map((r) =>
+      r.kind === "workflow" ? `wf:${r.workflow.workflow_id}` : `step:${r.step.function_id}`,
+    );
+    // The errored spawn keeps its own row ahead of the child subtree.
+    expect(labels).toEqual(["wf:root", "step:0", "wf:child"]);
+  });
+
+  it("degrades a second spawn of the same child to a plain step row", () => {
+    const family = [
+      wf({ workflow_id: "root" }),
+      wf({ workflow_id: "child", parent_workflow_id: "root" }),
+    ];
+    const steps = [
+      step({
+        workflow_id: "root",
+        function_id: 0,
+        function_name: "child_wf",
+        child_workflow_id: "child",
+      }),
+      step({
+        workflow_id: "root",
+        function_id: 1,
+        function_name: "child_wf",
+        child_workflow_id: "child",
+      }),
+    ];
+    const rows = buildTimelineRows(family, steps);
+    const labels = rows.map((r) =>
+      r.kind === "workflow" ? `wf:${r.workflow.workflow_id}` : `step:${r.step.function_id}`,
+    );
+    expect(labels).toEqual(["wf:root", "wf:child", "step:1"]);
+  });
+
+  it("terminates on parent-pointer cycles", () => {
+    const family = [
+      wf({ workflow_id: "a", parent_workflow_id: "b" }),
+      wf({ workflow_id: "b", parent_workflow_id: "a" }),
+    ];
+    const rows = buildTimelineRows(family, []);
+    expect(rows.map((r) => r.kind === "workflow" && r.workflow.workflow_id)).toEqual(["a", "b"]);
+  });
+
   it("emits unlinked family members instead of dropping them", () => {
     const family = [
       wf({ workflow_id: "root" }),
@@ -124,6 +182,17 @@ describe("spans", () => {
 
   it("returns null without a start time", () => {
     expect(stepSpan(step({ workflow_id: "w", function_id: 0, started_at: null }), now)).toBeNull();
+  });
+
+  it("treats a sleep without sleep_requested_ms like an ordinary step", () => {
+    const s = step({
+      workflow_id: "w",
+      function_id: 0,
+      function_name: "DBOS.sleep",
+      completed_at: iso(5),
+      sleep_requested_ms: null,
+    });
+    expect(stepSpan(s, now)).toEqual({ start: T0, end: T0 + 5, openEnded: false });
   });
 
   it("spans a sleep to its wake-up, not its recorded completion", () => {
@@ -293,5 +362,31 @@ describe("scaleTicks", () => {
     const scale = buildTimeScale([0, 10_000], false)!;
     const ticks = scaleTicks(scale, 5);
     expect(ticks.map((t) => t.offsetMs)).toEqual([0, 2000, 4000, 6000, 8000]);
+  });
+
+  it("anchors a tick at the end of a mid-scale break", () => {
+    // 4x 1s gaps, a 100s wait, 4x 1s gaps. The wait clamps to the 1s median
+    // weight, so its end sits at x = 5/9 with real time resuming at 104s.
+    const times = [0, 1000, 2000, 3000, 4000, 104_000, 105_000, 106_000, 107_000, 108_000];
+    const scale = buildTimeScale(times, true)!;
+    const ticks = scaleTicks(scale, 9);
+    const anchor = ticks.find((t) => Math.abs(t.x - 5 / 9) < 1e-9);
+    expect(anchor).toBeDefined();
+    expect(anchor!.offsetMs).toBe(104_000);
+  });
+
+  it("dedupes break anchors that crowd each other", () => {
+    // Two 100s waits separated by only 100ms. Both clamp to the 1s weight;
+    // with a coarse tick budget their anchors fall within minGap and only
+    // the first survives.
+    const times = [0, 1000, 2000, 3000, 4000, 104_000, 104_100, 204_100, 205_100, 206_100];
+    const scale = buildTimeScale(times, true)!;
+    const compressed = scale.segments.filter((s) => s.compressed);
+    expect(compressed.length).toBe(2);
+    const ticks = scaleTicks(scale, 3);
+    const anchors = ticks.filter((t) =>
+      compressed.some((s) => Math.abs(s.x1 - t.x) < 1e-9),
+    );
+    expect(anchors.length).toBe(1);
   });
 });

--- a/apps/console/src/lib/timeline.ts
+++ b/apps/console/src/lib/timeline.ts
@@ -23,6 +23,7 @@ export type TimelineStep = {
   function_id: number;
   function_name: string;
   has_error: boolean;
+  has_output: boolean;
   child_workflow_id: string | null;
   started_at: string | null;
   completed_at: string | null;
@@ -75,6 +76,13 @@ export function buildTimelineRows(
           ? byId.get(s.child_workflow_id)
           : undefined;
       if (child && !visited.has(child.workflow_id)) {
+        // A spawn op that carries signal of its own — an error (e.g. a queue
+        // dedup rejection) or a recorded payload — keeps a selectable row
+        // ahead of the child subtree. Ordinary spawns record neither, and
+        // stay collapsed into the child's header row. (Issue #20, option B.)
+        if (s.has_error || s.has_output) {
+          rows.push({ kind: "step", step: s, depth: depth + 1 });
+        }
         emit(child, s, depth + 1);
       } else {
         rows.push({ kind: "step", step: s, depth: depth + 1 });
@@ -102,6 +110,42 @@ const TERMINAL_STATUSES = new Set([
   "MAX_RECOVERY_ATTEMPTS_EXCEEDED",
 ]);
 
+// Span computation runs for every bar on every 1s "now" tick while a
+// workflow is live; cache the Date.parse results per row object. Realtime
+// snapshots replace row objects wholesale, so a cached entry can never go
+// stale, and the WeakMap lets dead snapshots be collected. (Issue #22.)
+const stepTimesCache = new WeakMap<TimelineStep, { start: number; end: number }>();
+
+function stepTimes(s: TimelineStep): { start: number; end: number } {
+  let t = stepTimesCache.get(s);
+  if (!t) {
+    t = {
+      start: s.started_at ? Date.parse(s.started_at) : NaN,
+      end: s.completed_at ? Date.parse(s.completed_at) : NaN,
+    };
+    stepTimesCache.set(s, t);
+  }
+  return t;
+}
+
+const wfTimesCache = new WeakMap<
+  TimelineWorkflow,
+  { start: number; end: number; updated: number }
+>();
+
+function wfTimes(w: TimelineWorkflow): { start: number; end: number; updated: number } {
+  let t = wfTimesCache.get(w);
+  if (!t) {
+    t = {
+      start: Date.parse(w.started_at),
+      end: w.completed_at ? Date.parse(w.completed_at) : NaN,
+      updated: Date.parse(w.updated_at),
+    };
+    wfTimesCache.set(w, t);
+  }
+  return t;
+}
+
 // DBOS writes the operation_outputs row only when a step finishes, with one
 // exception: sleeps are recorded up-front with started ≈ completed and the
 // wake-up encoded in the output (surfaced as sleep_requested_ms). So a
@@ -119,8 +163,7 @@ export function stepSpan(
   now: number,
   workflowEnd: number | null = null,
 ): Span | null {
-  if (!s.started_at) return null;
-  const start = Date.parse(s.started_at);
+  const { start, end: completed } = stepTimes(s);
   if (Number.isNaN(start)) return null;
   const clamp = (span: Span): Span =>
     workflowEnd !== null && span.end > workflowEnd
@@ -131,25 +174,26 @@ export function stepSpan(
     if (wake > now) return clamp({ start, end: Math.max(now, start), openEnded: true });
     return clamp({ start, end: wake, openEnded: false });
   }
-  if (s.completed_at) {
-    const end = Date.parse(s.completed_at);
-    if (!Number.isNaN(end)) return { start, end: Math.max(end, start), openEnded: false };
+  if (!Number.isNaN(completed)) {
+    return { start, end: Math.max(completed, start), openEnded: false };
   }
   return clamp({ start, end: Math.max(now, start), openEnded: true });
 }
 
 export function workflowSpan(w: TimelineWorkflow, now: number): Span | null {
-  const start = Date.parse(w.started_at);
+  const { start, end: completed, updated } = wfTimes(w);
   if (Number.isNaN(start)) return null;
-  if (w.completed_at) {
-    const end = Date.parse(w.completed_at);
-    if (!Number.isNaN(end)) return { start, end: Math.max(end, start), openEnded: false };
+  if (!Number.isNaN(completed)) {
+    return { start, end: Math.max(completed, start), openEnded: false };
   }
   if (TERMINAL_STATUSES.has(w.status ?? "")) {
     // Terminal but no completed_at (data recorded by an older DBOS): fall
     // back to updated_at rather than extending the bar to `now` forever.
-    const end = Date.parse(w.updated_at);
-    return { start, end: Number.isNaN(end) ? start : Math.max(end, start), openEnded: false };
+    return {
+      start,
+      end: Number.isNaN(updated) ? start : Math.max(updated, start),
+      openEnded: false,
+    };
   }
   return { start, end: Math.max(now, start), openEnded: true };
 }
@@ -247,17 +291,31 @@ export function buildTimeScale(
   const min = uniq[0];
   const max = uniq[uniq.length - 1];
 
+  // Binary search over segments (sorted, contiguous): toX/fromX run for
+  // every bar edge on every render tick, so a linear scan is the difference
+  // between O(bars) and O(bars·segments) per second on large families.
+  function segmentFor(value: number, upper: (s: ScaleSegment) => number): ScaleSegment {
+    let lo = 0;
+    let hi = segments.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (value <= upper(segments[mid])) hi = mid;
+      else lo = mid + 1;
+    }
+    return segments[lo];
+  }
+
   function toX(t: number): number {
     if (t <= min) return 0;
     if (t >= max) return 1;
-    const seg = segments.find((s) => t <= s.t1)!;
+    const seg = segmentFor(t, (s) => s.t1);
     return seg.x0 + ((t - seg.t0) / (seg.t1 - seg.t0)) * (seg.x1 - seg.x0);
   }
 
   function fromX(x: number): number {
     if (x <= 0) return min;
     if (x >= 1) return max;
-    const seg = segments.find((s) => x <= s.x1)!;
+    const seg = segmentFor(x, (s) => s.x1);
     return seg.t0 + ((x - seg.x0) / (seg.x1 - seg.x0)) * (seg.t1 - seg.t0);
   }
 
@@ -283,7 +341,13 @@ export function scaleTicks(scale: TimeScale, count: number): Tick[] {
   const minGap = 0.5 / count;
   const ticks: Tick[] = [];
   for (const s of scale.segments) {
-    if (s.compressed && s.x1 < 0.98) {
+    // Anchors also dedupe against each other: two breaks separated by a
+    // narrow linear stretch would otherwise overlap their labels.
+    if (
+      s.compressed &&
+      s.x1 < 0.98 &&
+      !ticks.some((t) => Math.abs(t.x - s.x1) < minGap)
+    ) {
       ticks.push({ x: s.x1, offsetMs: s.t1 - scale.min });
     }
   }

--- a/apps/console/src/lib/timeline.ts
+++ b/apps/console/src/lib/timeline.ts
@@ -1,0 +1,286 @@
+// Pure logic for the workflow timeline (waterfall) view: row ordering,
+// per-row time spans, and the piecewise-linear time scale with optional
+// wait compression. Kept free of Svelte imports so it unit-tests directly.
+//
+// The types below are structural subsets of `FamilyWorkflow` / `Step` from
+// WorkflowFlow.svelte — declared here (rather than imported) so this module
+// doesn't depend on a .svelte file and stays loadable from plain vitest.
+
+export type TimelineWorkflow = {
+  workflow_id: string;
+  parent_workflow_id: string | null;
+  name: string | null;
+  status: string | null;
+  // COALESCE(started_at_epoch_ms, created_at) server-side: run start when the
+  // workflow has begun executing, enqueue time while it's still ENQUEUED.
+  started_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type TimelineStep = {
+  workflow_id: string;
+  function_id: number;
+  function_name: string;
+  has_error: boolean;
+  child_workflow_id: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  event_key: string | null;
+  sleep_requested_ms: number | null;
+};
+
+export type TimelineRow =
+  | {
+      kind: "workflow";
+      workflow: TimelineWorkflow;
+      // The parent step that spawned this workflow (null for the root). Its
+      // started_at marks the enqueue moment, which is what lets the view
+      // draw a queued segment before the child's own run start.
+      spawnStep: TimelineStep | null;
+      depth: number;
+    }
+  | { kind: "step"; step: TimelineStep; depth: number };
+
+// Trace ordering: each workflow emits a header row followed by its steps in
+// function_id order; a step that spawned a family child is replaced by that
+// child's entire subtree (the child's header row *is* the spawn step). This
+// mirrors the DFS the family list arrives in while interleaving children at
+// the exact call site instead of appending them after the parent's steps.
+export function buildTimelineRows(
+  family: TimelineWorkflow[],
+  steps: TimelineStep[],
+): TimelineRow[] {
+  const byId = new Map(family.map((w) => [w.workflow_id, w]));
+  const stepsByWf = new Map<string, TimelineStep[]>();
+  for (const s of steps) {
+    const list = stepsByWf.get(s.workflow_id) ?? [];
+    list.push(s);
+    stepsByWf.set(s.workflow_id, list);
+  }
+  for (const list of stepsByWf.values()) {
+    list.sort((a, b) => a.function_id - b.function_id);
+  }
+
+  const rows: TimelineRow[] = [];
+  const visited = new Set<string>();
+
+  function emit(wf: TimelineWorkflow, spawnStep: TimelineStep | null, depth: number) {
+    if (visited.has(wf.workflow_id)) return;
+    visited.add(wf.workflow_id);
+    rows.push({ kind: "workflow", workflow: wf, spawnStep, depth });
+    for (const s of stepsByWf.get(wf.workflow_id) ?? []) {
+      const child =
+        s.child_workflow_id && !s.function_name.startsWith("DBOS.")
+          ? byId.get(s.child_workflow_id)
+          : undefined;
+      if (child && !visited.has(child.workflow_id)) {
+        emit(child, s, depth + 1);
+      } else {
+        rows.push({ kind: "step", step: s, depth: depth + 1 });
+      }
+    }
+  }
+
+  for (const w of family) {
+    if (!w.parent_workflow_id || !byId.has(w.parent_workflow_id)) emit(w, null, 0);
+  }
+  // Family members whose spawn step hasn't been walked (defensive — a spawn
+  // op row should always exist once the child does).
+  for (const w of family) {
+    if (!visited.has(w.workflow_id)) emit(w, null, 0);
+  }
+  return rows;
+}
+
+export type Span = { start: number; end: number; openEnded: boolean };
+
+const TERMINAL_STATUSES = new Set([
+  "SUCCESS",
+  "ERROR",
+  "CANCELLED",
+  "MAX_RECOVERY_ATTEMPTS_EXCEEDED",
+]);
+
+// DBOS writes the operation_outputs row only when a step finishes, with one
+// exception: sleeps are recorded up-front with started ≈ completed and the
+// wake-up encoded in the output (surfaced as sleep_requested_ms). So a
+// sleep's true extent is start → start+requested, clamped to `now` while the
+// workflow is still parked.
+export function stepSpan(s: TimelineStep, now: number): Span | null {
+  if (!s.started_at) return null;
+  const start = Date.parse(s.started_at);
+  if (Number.isNaN(start)) return null;
+  if (s.function_name === "DBOS.sleep" && s.sleep_requested_ms != null) {
+    const wake = start + s.sleep_requested_ms;
+    if (wake > now) return { start, end: Math.max(now, start), openEnded: true };
+    return { start, end: wake, openEnded: false };
+  }
+  if (s.completed_at) {
+    const end = Date.parse(s.completed_at);
+    if (!Number.isNaN(end)) return { start, end: Math.max(end, start), openEnded: false };
+  }
+  return { start, end: Math.max(now, start), openEnded: true };
+}
+
+export function workflowSpan(w: TimelineWorkflow, now: number): Span | null {
+  const start = Date.parse(w.started_at);
+  if (Number.isNaN(start)) return null;
+  if (w.completed_at) {
+    const end = Date.parse(w.completed_at);
+    if (!Number.isNaN(end)) return { start, end: Math.max(end, start), openEnded: false };
+  }
+  if (TERMINAL_STATUSES.has(w.status ?? "")) {
+    // Terminal but no completed_at (data recorded by an older DBOS): fall
+    // back to updated_at rather than extending the bar to `now` forever.
+    const end = Date.parse(w.updated_at);
+    return { start, end: Number.isNaN(end) ? start : Math.max(end, start), openEnded: false };
+  }
+  return { start, end: Math.max(now, start), openEnded: true };
+}
+
+export type ScaleSegment = {
+  t0: number;
+  t1: number;
+  x0: number;
+  x1: number;
+  compressed: boolean;
+};
+
+export type TimeScale = {
+  min: number;
+  max: number;
+  segments: ScaleSegment[];
+  // True when compression is on *and* at least one segment got clamped.
+  compressionApplied: boolean;
+  // True when compression would clamp something — drives the toggle's
+  // visibility independent of its current state.
+  wouldCompress: boolean;
+  toX(t: number): number;
+  fromX(x: number): number;
+};
+
+// A wait is "long" when it exceeds this multiple of the median executing-step
+// duration. 10x keeps ordinary traces (steps within one order of magnitude)
+// fully linear while a 14-day sleep next to 1s steps clamps hard. Once a
+// wait *is* clamped, it renders at the median itself (threshold / 10) — about
+// one typical step wide — so the reclaimed width goes to the actual work
+// instead of a big hatched band.
+const COMPRESS_MEDIAN_FACTOR = 10;
+const MIN_CAP_MS = 1_000;
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+// Piecewise-linear time → [0, 1] mapping. `times` are every bar boundary in
+// the view; the axis is linear within each inter-boundary segment. With
+// `compress`, segments longer than the cap contribute only the cap's worth
+// of width — since bar edges always sit on boundaries, every bar shrinks or
+// shifts consistently and nothing overlaps.
+//
+// `protect` marks intervals where a step was actually executing. They set
+// the cap (10x their median duration) and are exempt from clamping — the
+// view is called "compress waits", and squeezing a genuinely long step under
+// a hatched band would misread as idle time. Without any protected interval
+// (e.g. a family that only slept) the cap falls back to the median gap.
+export function buildTimeScale(
+  times: number[],
+  compress: boolean,
+  protect: Array<{ start: number; end: number }> = [],
+): TimeScale | null {
+  const uniq = [...new Set(times.filter((t) => Number.isFinite(t)))].sort((a, b) => a - b);
+  if (uniq.length < 2) return null;
+
+  const gaps: number[] = [];
+  for (let i = 1; i < uniq.length; i++) gaps.push(uniq[i] - uniq[i - 1]);
+  const protectDurations = protect
+    .map((p) => p.end - p.start)
+    .filter((d) => Number.isFinite(d) && d > 0);
+  const base = median(protectDurations) ?? median(gaps)!;
+  const cap = Math.max(base * COMPRESS_MEDIAN_FACTOR, MIN_CAP_MS);
+
+  function isProtected(t0: number, t1: number): boolean {
+    return protect.some((p) => p.start < t1 && p.end > t0);
+  }
+
+  const clampable = gaps.map(
+    (g, i) => g > cap && !isProtected(uniq[i], uniq[i + 1]),
+  );
+  const wouldCompress = clampable.some(Boolean);
+
+  const clampWeight = cap / COMPRESS_MEDIAN_FACTOR;
+  const weights = gaps.map((g, i) => (compress && clampable[i] ? clampWeight : g));
+  const total = weights.reduce((a, b) => a + b, 0);
+
+  const segments: ScaleSegment[] = [];
+  let acc = 0;
+  for (let i = 0; i < gaps.length; i++) {
+    const x0 = acc / total;
+    acc += weights[i];
+    segments.push({
+      t0: uniq[i],
+      t1: uniq[i + 1],
+      x0,
+      x1: acc / total,
+      compressed: compress && clampable[i],
+    });
+  }
+
+  const min = uniq[0];
+  const max = uniq[uniq.length - 1];
+
+  function toX(t: number): number {
+    if (t <= min) return 0;
+    if (t >= max) return 1;
+    const seg = segments.find((s) => t <= s.t1)!;
+    return seg.x0 + ((t - seg.t0) / (seg.t1 - seg.t0)) * (seg.x1 - seg.x0);
+  }
+
+  function fromX(x: number): number {
+    if (x <= 0) return min;
+    if (x >= 1) return max;
+    const seg = segments.find((s) => x <= s.x1)!;
+    return seg.t0 + ((x - seg.x0) / (seg.x1 - seg.x0)) * (seg.t1 - seg.t0);
+  }
+
+  return {
+    min,
+    max,
+    segments,
+    compressionApplied: compress && wouldCompress,
+    wouldCompress,
+    toX,
+    fromX,
+  };
+}
+
+export type Tick = { x: number; offsetMs: number };
+
+// Evenly spaced ticks in *visual* space, mapped back to time. Ticks landing
+// strictly inside a compressed segment are dropped — the time there is
+// distorted by design and the break band already marks it. Each compressed
+// segment instead contributes a tick at its end, so the axis re-anchors
+// where real time resumes after a break.
+export function scaleTicks(scale: TimeScale, count: number): Tick[] {
+  const minGap = 0.5 / count;
+  const ticks: Tick[] = [];
+  for (const s of scale.segments) {
+    if (s.compressed && s.x1 < 0.98) {
+      ticks.push({ x: s.x1, offsetMs: s.t1 - scale.min });
+    }
+  }
+  for (let i = 0; i < count; i++) {
+    const x = i / count;
+    const inCompressed = scale.segments.some(
+      (s) => s.compressed && x > s.x0 && x < s.x1,
+    );
+    if (inCompressed) continue;
+    // Break anchors win over even ticks when they'd crowd each other.
+    if (ticks.some((t) => Math.abs(t.x - x) < minGap)) continue;
+    ticks.push({ x, offsetMs: scale.fromX(x) - scale.min });
+  }
+  return ticks.sort((a, b) => a.x - b.x);
+}

--- a/apps/console/src/lib/timeline.ts
+++ b/apps/console/src/lib/timeline.ts
@@ -107,20 +107,35 @@ const TERMINAL_STATUSES = new Set([
 // wake-up encoded in the output (surfaced as sleep_requested_ms). So a
 // sleep's true extent is start → start+requested, clamped to `now` while the
 // workflow is still parked.
-export function stepSpan(s: TimelineStep, now: number): Span | null {
+//
+// `workflowEnd` is the owning workflow's terminal completion time (null while
+// it's still running). Inferred extents — a sleep's projected wake, an
+// open-ended stretch to `now` — are clamped to it so a workflow cancelled
+// mid-sleep doesn't render the sleep running to term (or still pulsing) after
+// the workflow is dead. Recorded completed_at timestamps are facts and are
+// never clamped.
+export function stepSpan(
+  s: TimelineStep,
+  now: number,
+  workflowEnd: number | null = null,
+): Span | null {
   if (!s.started_at) return null;
   const start = Date.parse(s.started_at);
   if (Number.isNaN(start)) return null;
+  const clamp = (span: Span): Span =>
+    workflowEnd !== null && span.end > workflowEnd
+      ? { start: span.start, end: Math.max(workflowEnd, span.start), openEnded: false }
+      : span;
   if (s.function_name === "DBOS.sleep" && s.sleep_requested_ms != null) {
     const wake = start + s.sleep_requested_ms;
-    if (wake > now) return { start, end: Math.max(now, start), openEnded: true };
-    return { start, end: wake, openEnded: false };
+    if (wake > now) return clamp({ start, end: Math.max(now, start), openEnded: true });
+    return clamp({ start, end: wake, openEnded: false });
   }
   if (s.completed_at) {
     const end = Date.parse(s.completed_at);
     if (!Number.isNaN(end)) return { start, end: Math.max(end, start), openEnded: false };
   }
-  return { start, end: Math.max(now, start), openEnded: true };
+  return clamp({ start, end: Math.max(now, start), openEnded: true });
 }
 
 export function workflowSpan(w: TimelineWorkflow, now: number): Span | null {

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { page } from "$app/state";
+  import { replaceState } from "$app/navigation";
   import PanelRightOpen from "@lucide/svelte/icons/panel-right-open";
   import ResultPane, {
     type ResultData,
@@ -11,6 +12,8 @@
     type FlowSelection,
     type Step,
   } from "$lib/components/WorkflowFlow.svelte";
+  import WorkflowTimeline from "$lib/components/WorkflowTimeline.svelte";
+  import * as ToggleGroup from "$lib/components/ui/toggle-group";
   import { breadcrumb } from "$lib/breadcrumb.svelte";
   import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
 
@@ -70,6 +73,36 @@
     }
   }
   let collapsed = $state(loadCollapsed());
+
+  // Graph vs timeline. The URL query wins (so links carry the view), then
+  // the last locally chosen view, then the graph default. Changes rewrite
+  // the query via replaceState — no history entry per toggle.
+  type DetailView = "graph" | "timeline";
+  const VIEW_KEY = "argus.workflowDetail.view";
+  function loadView(): DetailView {
+    const q = page.url.searchParams.get("view");
+    if (q === "graph" || q === "timeline") return q;
+    try {
+      if (typeof localStorage !== "undefined" && localStorage.getItem(VIEW_KEY) === "timeline")
+        return "timeline";
+    } catch {
+      // localStorage may be unavailable — fall through to the default.
+    }
+    return "graph";
+  }
+  let view = $state<DetailView>(loadView());
+  function setView(v: DetailView) {
+    view = v;
+    try {
+      if (typeof localStorage !== "undefined") localStorage.setItem(VIEW_KEY, v);
+    } catch {
+      // Drop the write rather than crashing the handler.
+    }
+    const url = new URL(page.url.href);
+    if (v === "graph") url.searchParams.delete("view");
+    else url.searchParams.set("view", v);
+    replaceState(url, {});
+  }
   $effect(() => {
     if (typeof localStorage === "undefined") return;
     try {
@@ -298,14 +331,36 @@
     class="relative flex min-h-0 flex-1 overflow-hidden"
     class:select-none={dragging}
   >
-    <div class="min-h-0 min-w-0 flex-1">
-      <WorkflowFlow
-        family={detail.family}
-        steps={detail.steps}
-        currentId={detail.workflow_id}
-        {selection}
-        onSelect={(s) => (selection = s)}
-      />
+    <div class="relative min-h-0 min-w-0 flex-1">
+      {#if view === "graph"}
+        <WorkflowFlow
+          family={detail.family}
+          steps={detail.steps}
+          currentId={detail.workflow_id}
+          {selection}
+          onSelect={(s) => (selection = s)}
+        />
+      {:else}
+        <WorkflowTimeline
+          family={detail.family}
+          steps={detail.steps}
+          currentId={detail.workflow_id}
+          {selection}
+          onSelect={(s) => (selection = s)}
+        />
+      {/if}
+      <ToggleGroup.Root
+        class="bg-card shadow-surface absolute top-3 left-3 z-10 rounded-lg"
+        type="single"
+        variant="outline"
+        value={view}
+        onValueChange={(v) => {
+          if (v === "graph" || v === "timeline") setView(v);
+        }}
+      >
+        <ToggleGroup.Item value="graph" class="h-7 px-2.5">Graph</ToggleGroup.Item>
+        <ToggleGroup.Item value="timeline" class="h-7 px-2.5">Timeline</ToggleGroup.Item>
+      </ToggleGroup.Root>
     </div>
     {#if collapsed}
       <!-- Collapsed: the pane gives its space back to the graph and leaves

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -372,13 +372,16 @@
     </div>
     {#if collapsed}
       <!-- Collapsed: the pane gives its space back to the graph and leaves
-           only this floating expand button behind. -->
+           only this floating expand button behind. top-3/right-4 mirrors the
+           collapse button's spot inside the expanded pane (12px pane margin,
+           plus 4px of pr-1 header inset on the right) so the icon doesn't
+           move when toggling. -->
       <button
         type="button"
         onclick={() => (collapsed = false)}
         title="Expand details pane"
         aria-label="Expand details pane"
-        class="bg-card shadow-surface-lg text-muted-foreground hover:text-foreground hover:bg-muted absolute top-3 right-3 z-10 flex h-8 w-8 items-center justify-center rounded-lg"
+        class="bg-card shadow-surface-lg text-muted-foreground hover:text-foreground hover:bg-muted absolute top-3 right-4 z-10 flex h-8 w-8 items-center justify-center rounded-lg"
       >
         <PanelRightOpen class="size-4" />
       </button>
@@ -407,22 +410,31 @@
         </button>
       </div>
     {/if}
+    <!-- Collapse animates the wrapper's width to 0 (not `hidden`, which can't
+         transition). The inner holder keeps the pane's real width and anchors
+         right, so content neither reflows nor drifts while the left edge
+         sweeps shut. `visibility` rides the transition so it flips only at
+         the end (hiding the zero-width shadow sliver); `inert` keeps focus
+         out of the closed pane. -->
     <div
-      class="shadow-surface-lg absolute inset-y-3 right-3 w-[var(--result-pane-width)] max-w-[calc(100%-3rem)] flex-none overflow-hidden rounded-xl lg:static lg:my-3 lg:mr-3 lg:ml-2"
-      class:hidden={collapsed}
-      class:transition-[width]={!dragging}
+      class="shadow-surface-lg absolute inset-y-3 right-3 flex w-[var(--result-pane-width)] max-w-[calc(100%-3rem)] flex-none justify-end overflow-hidden rounded-xl lg:static lg:my-3 lg:mr-3 lg:ml-2"
+      class:invisible={collapsed}
+      inert={collapsed}
+      class:transition-[width,visibility]={!dragging}
       class:duration-200={!dragging}
-      class:ease-out={!dragging}
-      style="--result-pane-width: {rightWidth}px"
+      class:ease-in-out={!dragging}
+      style="--result-pane-width: {collapsed ? 0 : rightWidth}px"
     >
-      <ResultPane
-        {selection}
-        {result}
-        loading={resultLoading}
-        loadError={resultError}
-        events={detail.events}
-        onToggleCollapse={() => (collapsed = !collapsed)}
-      />
+      <div class="h-full max-w-[calc(100vw-3rem)]" style="width: {rightWidth}px">
+        <ResultPane
+          {selection}
+          {result}
+          loading={resultLoading}
+          loadError={resultError}
+          events={detail.events}
+          onToggleCollapse={() => (collapsed = !collapsed)}
+        />
+      </div>
     </div>
   </div>
 {/if}

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -341,13 +341,21 @@
           onSelect={(s) => (selection = s)}
         />
       {:else}
-        <WorkflowTimeline
-          family={detail.family}
-          steps={detail.steps}
-          currentId={detail.workflow_id}
-          {selection}
-          onSelect={(s) => (selection = s)}
-        />
+        <!-- Absolutely positioned: the app shell is a min-height layout that
+             grows with in-flow content, so a tall trace would push the whole
+             document instead of scrolling inside the timeline. Out-of-flow,
+             the container settles at the viewport-bounded stretch size (same
+             reason the xyflow canvas works) and the timeline's internal
+             scroller actually engages. -->
+        <div class="absolute inset-0">
+          <WorkflowTimeline
+            family={detail.family}
+            steps={detail.steps}
+            currentId={detail.workflow_id}
+            {selection}
+            onSelect={(s) => (selection = s)}
+          />
+        </div>
       {/if}
       <ToggleGroup.Root
         class="bg-card shadow-surface absolute top-3 left-3 z-10 rounded-lg"

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
   },
   server: {
     host: "0.0.0.0",
-    port: 5000,
+    // 4517 deliberately avoids common defaults (5000 is macOS AirPlay).
+    port: 4517,
     allowedHosts: true,
     proxy: {
       "/healthz": BACKEND_HTTP,

--- a/packages/server/dbos_argus/realtime/endpoint.py
+++ b/packages/server/dbos_argus/realtime/endpoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -99,7 +100,7 @@ async def _handle_client_message(hub: RealtimeHub, conn: Connection, msg: Any) -
     msg_type = msg.get("type")
 
     if msg_type == "ping":
-        conn.enqueue(PongMessage())
+        conn.enqueue(PongMessage(server_time_ms=int(time.time() * 1000)))
         return
 
     if msg_type == "subscribe":

--- a/packages/server/dbos_argus/realtime/hub.py
+++ b/packages/server/dbos_argus/realtime/hub.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -48,6 +49,12 @@ class Subscription:
     params: dict[str, Any] | None
     connection: Connection
     poller: Poller | None = None
+
+
+def _server_time_ms() -> int:
+    """Wall clock stamped onto outbound data messages (protocol
+    `server_time_ms`) so clients can correct for clock skew."""
+    return int(time.time() * 1000)
 
 
 def _make_out_queue() -> asyncio.Queue[ServerMessage]:
@@ -143,6 +150,7 @@ class Poller:
                     sub_id=sub.sub_id,
                     channel=self.channel.name,
                     data=self._last_snapshot,
+                    server_time_ms=_server_time_ms(),
                 )
             )
 
@@ -163,6 +171,7 @@ class Poller:
                     sub_id=sub.sub_id,
                     channel=self.channel.name,
                     data=self._last_snapshot,
+                    server_time_ms=_server_time_ms(),
                 )
             )
 
@@ -173,6 +182,7 @@ class Poller:
                     sub_id=sub.sub_id,
                     channel=self.channel.name,
                     data=self._last_snapshot,
+                    server_time_ms=_server_time_ms(),
                 )
             )
 

--- a/packages/server/dbos_argus/realtime/protocol.py
+++ b/packages/server/dbos_argus/realtime/protocol.py
@@ -54,6 +54,10 @@ class SnapshotMessage(BaseModel):
     sub_id: str
     channel: str
     data: Any
+    # Server wall clock (epoch ms) at enqueue time. Lets clients compute a
+    # clock-skew offset so UI geometry anchored on "now" (e.g. the timeline's
+    # live edge) lines up with server-recorded timestamps.
+    server_time_ms: int | None = None
 
 
 class UpdateMessage(BaseModel):
@@ -63,6 +67,7 @@ class UpdateMessage(BaseModel):
     sub_id: str
     channel: str
     data: Any
+    server_time_ms: int | None = None
 
 
 class ErrorMessage(BaseModel):
@@ -73,7 +78,10 @@ class ErrorMessage(BaseModel):
 
 
 class PongMessage(BaseModel):
+    # Heartbeat pongs also carry the server clock so the skew offset stays
+    # fresh on quiet connections with no data flowing.
     type: Literal["pong"] = "pong"
+    server_time_ms: int | None = None
 
 
 class AckMessage(BaseModel):

--- a/packages/server/tests/test_realtime_endpoint.py
+++ b/packages/server/tests/test_realtime_endpoint.py
@@ -77,7 +77,10 @@ def test_ping_pong() -> None:
     with TestClient(_make_app()) as client, client.websocket_connect("/ws") as ws:
         ws.send_json({"type": "ping"})
         msg = ws.receive_json()
-        assert msg == {"type": "pong"}
+        assert msg["type"] == "pong"
+        # Pongs carry the server clock so clients can correct for skew even
+        # on connections with no data flowing.
+        assert isinstance(msg["server_time_ms"], int)
 
 
 def test_unknown_channel_returns_error() -> None:

--- a/packages/server/tests/test_realtime_hub.py
+++ b/packages/server/tests/test_realtime_hub.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 from dbos_argus.realtime.channel import BroadcastChannel, KeyedChannel
@@ -126,6 +127,9 @@ async def test_subscribe_yields_ack_then_snapshot() -> None:
     assert msgs[1].sub_id == "s1"
     assert msgs[1].channel == "counter"
     assert msgs[1].data == {"tick": 1}
+    # Data messages carry the server clock so clients can correct for skew.
+    assert msgs[1].server_time_ms is not None
+    assert abs(msgs[1].server_time_ms - time.time() * 1000) < 5_000
 
     hub.detach(conn)
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -8,7 +8,7 @@
 //   --demo           also run the sample-app workload (scripts/demo-app.mjs)
 //
 // Always starts the FastAPI backend (uvicorn on :8090) and the SvelteKit dev
-// server (:5000) through a single `concurrently` child. DB URLs are set via
+// server (:4517) through a single `concurrently` child. DB URLs are set via
 // process.env so they propagate to every subprocess without POSIX inline
 // `VAR=val cmd` syntax, which is shell-specific.
 //

--- a/scripts/replit-deploy.sh
+++ b/scripts/replit-deploy.sh
@@ -33,4 +33,4 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-exec uv run dbos-argus --host 0.0.0.0 --port "${PORT:-5000}"
+exec uv run dbos-argus --host 0.0.0.0 --port "${PORT:-4517}"

--- a/tests/sample-app/README.md
+++ b/tests/sample-app/README.md
@@ -34,7 +34,7 @@ pnpm demo
 
 That sets `ARGUS_DATABASE_URL` and `DBOS_SYSTEM_DATABASE_URL` to the same `argus-demo.sqlite` file at the repo root, then `scripts/dev.mjs` brings up:
 
-- the FastAPI backend (uvicorn on :8090) and the SvelteKit dev server (:5000)
+- the FastAPI backend (uvicorn on :8090) and the SvelteKit dev server (:4517)
 - the sample-app workload via `scripts/demo-app.mjs` (one-shot `argus-runner prepare`, then simulator + scheduler + metrics-runner)
 
 Ctrl+C tears everything down together.


### PR DESCRIPTION
Adds a timeline view to the workflow detail page: per-step bars laid out on the workflow's time axis (`WorkflowTimeline.svelte` + `timeline.ts`), with inferred step extents clamped to workflow death so a crashed run doesn't stretch open-ended bars to now.

Server side, the realtime protocol/hub/endpoint gain what the view needs, with tests on both sides (console suite and `test_realtime_*`).

Also in here from the same stretch of work:
- detail pane collapse is animated and the pin toggle icon stays in place
- console dev server moves from port 5000 to 4517