### PR TITLE
Serve Argus behind a reverse proxy on any subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (server wall clock at enqueue). The console uses it to correct for client
   clock skew when positioning the timeline's live edge; older servers that
   omit the field fall back to the client clock unchanged.
+- Serve Argus behind a reverse proxy on any subpath. The console now uses
+  hash routing (`/#/workflows/...`) and relative asset/API/WebSocket URLs, so
+  the same build works at `/` or behind a stripped prefix (e.g. `/argus/`)
+  with no configuration — see "Behind a reverse proxy, on a subpath" in the
+  README. Legacy path-style deep links redirect to the hash form via a shim in
+  the shell.
 
 ### Changed
 - Console dev server moved from port 5000 to 4517 (Vite, Playwright, the
@@ -34,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of snapping, and its collapse/expand button keeps the exact same
   screen position in both states. The pane header is tighter: content hugs
   the card's top edge with the toggle inset 4px from the corner.
+- Internal console links and `goto()` calls use the `#/...` form; the adapter
+  fallback is written to `404.html` so the prerendered `index.html` shell (the
+  one the server's SPA catch-all serves) keeps its runtime-computed base, and
+  a post-build step rewrites the shell's entry imports and preloads to
+  relative URLs.
 
 ## [0.0.35] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ Multi-arch: `linux/amd64` + `linux/arm64`. Pulled from [`tmarkovski/dbos-argus`]
 | `ARGUS_DATABASE_URL` | SQLAlchemy async URL to the database your DBOS app writes to. Postgres (`postgresql+asyncpg://...`, or bare `postgresql://` / `postgres://` which Argus rewrites) and SQLite (`sqlite+aiosqlite:///...`, or bare `sqlite:///...`) are both supported. |
 | `ARGUS_CORS_ORIGINS` | Comma-separated allowed origins for the console / WebSocket. Defaults to `*` since Argus is an unauthenticated dev tool typically bound to localhost; narrow this if you expose Argus beyond localhost. |
 
+### Behind a reverse proxy, on a subpath
+
+Argus is mount-point agnostic: the console uses hash routing (`/#/workflows/...`)
+with relative asset, API, and WebSocket URLs, so the same image works served at
+`/` or behind any path prefix. No Argus configuration is involved — route the
+prefix to the container and strip it, e.g. nginx:
+
+```nginx
+location /argus/ {
+  proxy_pass http://argus:8090/;   # trailing slash strips the /argus prefix
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;   # WebSocket for the live console
+  proxy_set_header Connection "upgrade";
+}
+```
+
+Link to `/argus/` (with the trailing slash). Pre-0.0.36 path-style deep links
+(`/workflows/<id>`) redirect to the hash form automatically.
+
 ## Why Argus exists
 
 We built this because we like [DBOS](https://www.dbos.dev/). A lot.

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --host 0.0.0.0 --port 4517",
-    "build": "svelte-kit sync && vite build",
+    "build": "svelte-kit sync && vite build && node scripts/relativize-shell.mjs",
     "preview": "vite preview --host 0.0.0.0 --port 4517",
     "lint": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --threshold warning",
     "test": "vitest run",

--- a/apps/console/scripts/relativize-shell.mjs
+++ b/apps/console/scripts/relativize-shell.mjs
@@ -1,0 +1,20 @@
+// Make the built shell mount-point agnostic.
+//
+// With hash routing, SvelteKit already computes the runtime `base` from
+// `location`, but the prerendered index.html still emits the entry imports,
+// modulepreload links, and favicon hrefs as root-absolute URLs ("/_app/...").
+// Served behind a stripped reverse-proxy prefix those resolve outside the
+// mount and 404. The document URL is always the mount root in hash mode, so
+// plain relative URLs are correct everywhere — at "/" and behind any prefix.
+//
+// 404.html (the adapter fallback) is left untouched: the Argus server's SPA
+// catch-all serves index.html itself, and a fallback served at an unknown
+// depth is exactly the case relative URLs cannot handle.
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const path = fileURLToPath(new URL("../build/index.html", import.meta.url));
+const html = readFileSync(path, "utf8");
+const out = html.replaceAll('href="/', 'href="./').replaceAll('import("/', 'import("./');
+writeFileSync(path, out);
+console.log("relativized build/index.html");

--- a/apps/console/src/app.html
+++ b/apps/console/src/app.html
@@ -9,6 +9,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Argus</title>
     <script>
+      // Legacy path-based deep links (pre-hash-routing bookmarks like
+      // /workflows/<id>) land on this shell via the SPA fallback; rewrite them
+      // to the hash form, preserving any reverse-proxy mount prefix.
+      (function () {
+        var m = window.location.pathname.match(
+          /^(.*?)\/((?:workflows|queues|schedules|notifications)\/.*)$/
+        );
+        if (m && !window.location.hash) {
+          window.location.replace(m[1] + "/#/" + m[2] + window.location.search);
+        }
+      })();
+    </script>
+    <script>
       (function () {
         try {
           var stored = localStorage.getItem("theme");

--- a/apps/console/src/lib/components/ResultPane.svelte
+++ b/apps/console/src/lib/components/ResultPane.svelte
@@ -167,7 +167,7 @@
         label: "Child",
         value: s.child_workflow_id,
         title: s.child_workflow_id,
-        href: `/workflows/${encodeURIComponent(s.child_workflow_id)}/`,
+        href: `#/workflows/${encodeURIComponent(s.child_workflow_id)}/`,
       });
     if (s.event_key) items.push({ label: "Event key", value: s.event_key });
     if (s.sleep_requested_ms !== null)

--- a/apps/console/src/lib/connection-state.svelte.ts
+++ b/apps/console/src/lib/connection-state.svelte.ts
@@ -96,7 +96,9 @@ class ConnectionState {
     this.diagnosticsError = null;
     this.diagnosticsLoading = true;
     try {
-      const res = await fetch("/api/sql-diagnostics");
+      // Relative (no leading slash) so it resolves against wherever the
+      // console is mounted — root or behind a reverse-proxy prefix.
+      const res = await fetch("api/sql-diagnostics");
       if (!res.ok) {
         let detail = `HTTP ${res.status}`;
         try {

--- a/apps/console/src/lib/realtime/client.svelte.ts
+++ b/apps/console/src/lib/realtime/client.svelte.ts
@@ -49,7 +49,7 @@ type InternalSub = {
 export type ClientOptions = {
   /** Socket factory. Defaults to `new WebSocket(url)`. Tests inject a fake. */
   socketFactory?: (url: string) => WebSocket;
-  /** Override the URL. Defaults to `${ws|wss}://${location.host}/ws`. */
+  /** Override the URL. Defaults to `ws(s)://<document base>/ws` — relative to wherever the console is mounted. */
   url?: string;
   /**
    * Heartbeat interval. A `ping` is sent every `heartbeatMs`; if no `pong`
@@ -106,7 +106,10 @@ export class RealtimeClient {
     const url =
       options.url ??
       (typeof window !== "undefined"
-        ? `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`
+        ? // Resolved against the document base (hash excluded), so the socket
+          // lands next to the API wherever the console is mounted — root or
+          // behind a reverse-proxy prefix. http(s):// becomes ws(s)://.
+          new URL("ws", document.baseURI).href.replace(/^http/, "ws")
         : "ws://localhost/ws");
     this.opts = {
       url,

--- a/apps/console/src/lib/route-url.test.ts
+++ b/apps/console/src/lib/route-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { routeUrl } from "./route-url";
+
+describe("routeUrl", () => {
+  it("extracts the route from the fragment at the root mount", () => {
+    const u = routeUrl(new URL("http://h/#/workflows/abc/"));
+    expect(u.pathname).toBe("/workflows/abc/");
+  });
+
+  it("extracts the route behind a reverse-proxy mount prefix", () => {
+    const u = routeUrl(new URL("http://h/argus/#/workflows/abc/"));
+    expect(u.pathname).toBe("/workflows/abc/");
+  });
+
+  it("surfaces query params carried inside the fragment", () => {
+    const u = routeUrl(new URL("http://h/argus/#/workflows/?queue_name=q1&view=timeline"));
+    expect(u.pathname).toBe("/workflows/");
+    expect(u.searchParams.get("queue_name")).toBe("q1");
+    expect(u.searchParams.get("view")).toBe("timeline");
+  });
+
+  it("treats a missing fragment as the root route regardless of mount", () => {
+    expect(routeUrl(new URL("http://h/")).pathname).toBe("/");
+    expect(routeUrl(new URL("http://h/argus/")).pathname).toBe("/");
+  });
+
+  it("treats a plain in-page anchor as the root route", () => {
+    expect(routeUrl(new URL("http://h/argus/#section")).pathname).toBe("/");
+  });
+});

--- a/apps/console/src/lib/route-url.ts
+++ b/apps/console/src/lib/route-url.ts
@@ -1,0 +1,11 @@
+/**
+ * Under the hash router, `page.url` is the *browser* URL: the route and its
+ * query live in the fragment, and the pathname is wherever the console
+ * happens to be mounted (`/`, `/argus/`, ...). Normalize to a URL whose
+ * pathname and searchParams are the route's own — use this instead of
+ * reading `page.url.pathname` / `page.url.searchParams` directly.
+ */
+export function routeUrl(pageUrl: URL): URL {
+  const hash = pageUrl.hash;
+  return new URL(hash.startsWith("#/") ? hash.slice(1) : "/", pageUrl.origin);
+}

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
   import Bell from "@lucide/svelte/icons/bell";
   import { page } from "$app/state";
   import { breadcrumb } from "$lib/breadcrumb.svelte";
+  import { routeUrl } from "$lib/route-url";
   import {
     argusPinCommand,
     connectionIndicatorClass,
@@ -82,7 +83,7 @@
     return n > 99 ? "99+" : String(n);
   }
 
-  const pathname = $derived(page.url.pathname);
+  const pathname = $derived(routeUrl(page.url).pathname);
   function isActive(href: string): boolean {
     // The Home link points at "/" — every other path starts with "/", so it
     // would otherwise match everywhere. Treat root as exact-match-only.

--- a/apps/console/src/routes/+layout.svelte
+++ b/apps/console/src/routes/+layout.svelte
@@ -192,7 +192,7 @@
         <Sidebar.MenuItem>
           <Sidebar.MenuButton size="lg">
             {#snippet child({ props })}
-              <a href="/" {...props}>
+              <a href="#/" {...props}>
                 <div
                   class="bg-primary text-primary-foreground flex aspect-square size-8 items-center justify-center rounded-full"
                 >
@@ -225,7 +225,9 @@
                   tooltipContent={item.label}
                 >
                   {#snippet child({ props })}
-                    <a href={item.href} {...props}>
+                    <!-- item.href stays a plain route path for isActive(); the
+                         hash router needs the "#" on the anchor itself. -->
+                    <a href={"#" + item.href} {...props}>
                       <item.icon />
                       <span>{item.label}</span>
                     </a>

--- a/apps/console/src/routes/+layout.ts
+++ b/apps/console/src/routes/+layout.ts
@@ -1,3 +1,0 @@
-export const ssr = false;
-export const prerender = false;
-export const trailingSlash = "always";

--- a/apps/console/src/routes/+page.svelte
+++ b/apps/console/src/routes/+page.svelte
@@ -89,9 +89,9 @@
     queuesHandle?.dispose();
   });
 
-  const inFlightHref = "/workflows/?status=PENDING&status=ENQUEUED&status=DELAYED";
-  const enqueuedHref = "/workflows/?status=ENQUEUED";
-  const failedHref = "/workflows/?status=ERROR&status=MAX_RECOVERY_ATTEMPTS_EXCEEDED";
+  const inFlightHref = "#/workflows/?status=PENDING&status=ENQUEUED&status=DELAYED";
+  const enqueuedHref = "#/workflows/?status=ENQUEUED";
+  const failedHref = "#/workflows/?status=ERROR&status=MAX_RECOVERY_ATTEMPTS_EXCEEDED";
 
   const connectionIndicatorState = $derived(
     getConnectionIndicatorState({
@@ -183,7 +183,7 @@
   >
     <Card.Root>
       <a
-        href="/workflows/"
+        href="#/workflows/"
         class="absolute inset-0 rounded-lg"
         aria-label="View all workflows"
       ></a>
@@ -227,7 +227,7 @@
 
     <Card.Root>
       <a
-        href="/notifications/"
+        href="#/notifications/"
         class="absolute inset-0 rounded-lg"
         aria-label="View notifications"
       ></a>
@@ -255,7 +255,7 @@
 
     <Card.Root>
       <a
-        href="/schedules/"
+        href="#/schedules/"
         class="absolute inset-0 rounded-lg"
         aria-label="View schedules"
       ></a>
@@ -283,7 +283,7 @@
 
     <Card.Root>
       <a
-        href="/queues/"
+        href="#/queues/"
         class="absolute inset-0 rounded-lg"
         aria-label="View queues"
       ></a>
@@ -314,7 +314,7 @@
           </div>
           {#each topQueues as q (q.queue_id)}
             <a
-              href="/workflows/?queue_name={encodeURIComponent(
+              href="#/workflows/?queue_name={encodeURIComponent(
                 q.name,
               )}&status=ENQUEUED&status=PENDING"
               class="group relative z-10 flex items-center gap-3 text-xs"
@@ -350,7 +350,7 @@
         <Card.Description>The most recent workflow runs from this database.</Card.Description>
         <Card.Action>
           <a
-            href="/workflows/"
+            href="#/workflows/"
             class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-sm"
           >
             View all
@@ -383,7 +383,7 @@
                 </Table.Cell>
                 <Table.Cell class="font-mono">
                   <a
-                    href="/workflows/{encodeURIComponent(w.workflow_id)}/"
+                    href="#/workflows/{encodeURIComponent(w.workflow_id)}/"
                     class="hover:text-foreground hover:underline"
                   >
                     {w.name ?? "—"}
@@ -397,7 +397,7 @@
                   title={w.workflow_id}
                 >
                   <a
-                    href="/workflows/{encodeURIComponent(w.workflow_id)}/"
+                    href="#/workflows/{encodeURIComponent(w.workflow_id)}/"
                     class="hover:text-foreground block truncate hover:underline"
                   >
                     {w.workflow_id}

--- a/apps/console/src/routes/notifications/+page.svelte
+++ b/apps/console/src/routes/notifications/+page.svelte
@@ -196,7 +196,7 @@
                           class="inline-block size-1.5 flex-none rounded-full {statusDotClass(a.status)}"
                         ></span>
                         <a
-                          href="/workflows/{encodeURIComponent(a.workflow_id)}/"
+                          href="#/workflows/{encodeURIComponent(a.workflow_id)}/"
                           onclick={(e) => e.stopPropagation()}
                           title={a.workflow_id}
                           class="hover:underline {isLast
@@ -215,7 +215,7 @@
                   </ol>
                 {:else}
                   <a
-                    href="/workflows/{encodeURIComponent(n.destination_uuid)}/"
+                    href="#/workflows/{encodeURIComponent(n.destination_uuid)}/"
                     onclick={(e) => e.stopPropagation()}
                     title={n.destination_uuid}
                     class="text-muted-foreground hover:text-foreground hover:underline"
@@ -339,7 +339,7 @@
                         class="inline-block size-1.5 flex-none rounded-full {statusDotClass(a.status)}"
                       ></span>
                       <a
-                        href="/workflows/{encodeURIComponent(a.workflow_id)}/"
+                        href="#/workflows/{encodeURIComponent(a.workflow_id)}/"
                         title={a.workflow_id}
                         class="hover:underline {isLast
                           ? 'text-foreground font-medium'
@@ -363,7 +363,7 @@
                 </p>
               {:else}
                 <a
-                  href="/workflows/{encodeURIComponent(selected.destination_uuid)}/"
+                  href="#/workflows/{encodeURIComponent(selected.destination_uuid)}/"
                   class="hover:text-foreground hover:underline font-mono text-sm break-all"
                 >
                   {selected.destination_uuid}

--- a/apps/console/src/routes/queues/+page.svelte
+++ b/apps/console/src/routes/queues/+page.svelte
@@ -115,7 +115,7 @@
             <Table.Row>
               <Table.Cell class="px-4 py-2 font-mono">
                 <a
-                  href="/workflows/?queue_name={encodeURIComponent(q.name)}"
+                  href="#/workflows/?queue_name={encodeURIComponent(q.name)}"
                   class="hover:text-foreground hover:underline"
                 >
                   {q.name}
@@ -124,7 +124,7 @@
               <Table.Cell class="px-4 py-2 text-right font-mono text-xs tabular-nums">
                 {#if q.enqueued > 0}
                   <a
-                    href="/workflows/?queue_name={encodeURIComponent(q.name)}&status=ENQUEUED"
+                    href="#/workflows/?queue_name={encodeURIComponent(q.name)}&status=ENQUEUED"
                     class="hover:text-foreground hover:underline"
                   >
                     {q.enqueued}
@@ -136,7 +136,7 @@
               <Table.Cell class="px-4 py-2 text-right font-mono text-xs tabular-nums">
                 {#if q.running > 0}
                   <a
-                    href="/workflows/?queue_name={encodeURIComponent(q.name)}&status=PENDING"
+                    href="#/workflows/?queue_name={encodeURIComponent(q.name)}&status=PENDING"
                     class="hover:text-foreground hover:underline"
                   >
                     {q.running}

--- a/apps/console/src/routes/schedules/+page.svelte
+++ b/apps/console/src/routes/schedules/+page.svelte
@@ -115,7 +115,7 @@
               <Table.Cell class="text-muted-foreground px-4 py-2 font-mono text-xs">
                 {#if s.queue_name}
                   <a
-                    href="/workflows/?queue_name={encodeURIComponent(s.queue_name)}"
+                    href="#/workflows/?queue_name={encodeURIComponent(s.queue_name)}"
                     class="hover:text-foreground hover:underline"
                   >
                     {s.queue_name}

--- a/apps/console/src/routes/workflows/+page.svelte
+++ b/apps/console/src/routes/workflows/+page.svelte
@@ -39,7 +39,7 @@
   $effect(() => {
     breadcrumb.items = queueName
       ? [
-          { label: "Workflows", href: "/workflows/", icon: "workflow" },
+          { label: "Workflows", href: "#/workflows/", icon: "workflow" },
           { label: `Queue: ${queueName}` },
         ]
       : [{ label: "Workflows", icon: "workflow" }];
@@ -400,7 +400,7 @@
   // than local state.
   function setQueueFilter(name: string) {
     queuePopoverOpen = false;
-    goto(name ? `/workflows/?queue_name=${encodeURIComponent(name)}` : "/workflows/", {
+    goto(name ? `#/workflows/?queue_name=${encodeURIComponent(name)}` : "#/workflows/", {
       noScroll: true,
       keepFocus: true,
     });
@@ -530,7 +530,7 @@
                   <td class="w-1 px-4 py-1.5 whitespace-nowrap">
                     {#if w.queue_name}
                       <a
-                        href="/workflows/?queue_name={encodeURIComponent(w.queue_name)}"
+                        href="#/workflows/?queue_name={encodeURIComponent(w.queue_name)}"
                         class="text-status-queued font-mono text-xs hover:underline"
                         title="Filter by queue {w.queue_name}"
                       >
@@ -552,7 +552,7 @@
                         />
                       {/if}
                       <a
-                        href="/workflows/{encodeURIComponent(w.workflow_id)}/"
+                        href="#/workflows/{encodeURIComponent(w.workflow_id)}/"
                         class="hover:underline"
                         title={isScheduled ? "Scheduled (cron) firing" : undefined}
                       >
@@ -562,7 +562,7 @@
                   </td>
                   <td class="text-muted-foreground px-4 py-1.5 font-mono text-xs">
                     <a
-                      href="/workflows/{encodeURIComponent(w.workflow_id)}/"
+                      href="#/workflows/{encodeURIComponent(w.workflow_id)}/"
                       class="hover:text-foreground hover:underline"
                       title={w.workflow_id}
                     >
@@ -828,12 +828,12 @@
                 // browser navigate them natively (preserves middle-click,
                 // ctrl/cmd-click, "open in new tab").
                 if ((e.target as HTMLElement).closest("a")) return;
-                goto(`/workflows/${encodeURIComponent(w.workflow_id)}/`);
+                goto(`#/workflows/${encodeURIComponent(w.workflow_id)}/`);
               }}
               onkeydown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  goto(`/workflows/${encodeURIComponent(w.workflow_id)}/`);
+                  goto(`#/workflows/${encodeURIComponent(w.workflow_id)}/`);
                 }
               }}
               tabindex={0}
@@ -872,7 +872,7 @@
                       </div>
                     {/each}
                     <a
-                      href="/workflows/{encodeURIComponent(w.workflow_id)}/"
+                      href="#/workflows/{encodeURIComponent(w.workflow_id)}/"
                       class="hover:text-foreground hover:underline {!grouped || w.depth === 0
                         ? 'py-1.5'
                         : 'py-0.5'} {grouped && w.depth > 0 ? 'pl-1' : ''}"
@@ -895,7 +895,7 @@
                     : 'py-0.5'}"
                 >
                   <a
-                    href="/workflows/{encodeURIComponent(w.workflow_id)}/"
+                    href="#/workflows/{encodeURIComponent(w.workflow_id)}/"
                     title={w.workflow_id}
                     class="hover:text-foreground hover:underline"
                   >
@@ -934,7 +934,7 @@
                 >
                   {#if w.queue_name}
                     <a
-                      href="/workflows/?queue_name={encodeURIComponent(w.queue_name)}"
+                      href="#/workflows/?queue_name={encodeURIComponent(w.queue_name)}"
                       class="hover:text-foreground hover:underline"
                     >
                       {w.queue_name}

--- a/apps/console/src/routes/workflows/+page.svelte
+++ b/apps/console/src/routes/workflows/+page.svelte
@@ -33,8 +33,9 @@
   import { breadcrumb } from "$lib/breadcrumb.svelte";
   import { statsState } from "$lib/stats.svelte";
   import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
+  import { routeUrl } from "$lib/route-url";
 
-  const queueName = $derived(page.url.searchParams.get("queue_name") ?? "");
+  const queueName = $derived(routeUrl(page.url).searchParams.get("queue_name") ?? "");
 
   $effect(() => {
     breadcrumb.items = queueName

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -98,9 +98,16 @@
     } catch {
       // Drop the write rather than crashing the handler.
     }
-    const url = new URL(page.url.href);
-    if (v === "graph") url.searchParams.delete("view");
-    else url.searchParams.set("view", v);
+    // Under hash routing the route and its query live in the URL fragment.
+    // page.url is the *decoded* form (route as pathname) — handing it to
+    // replaceState would rewrite the address bar to the path form, dropping
+    // the hash and any reverse-proxy mount prefix. Rewrite the query inside
+    // the fragment of the real browser URL instead.
+    const route = new URL(page.url.href);
+    if (v === "graph") route.searchParams.delete("view");
+    else route.searchParams.set("view", v);
+    const url = new URL(window.location.href);
+    url.hash = `#${route.pathname}${route.search}`;
     replaceState(url, {});
   }
   $effect(() => {
@@ -237,12 +244,14 @@
     let hasAny: boolean;
     if (sel.kind === "workflow") {
       key = `wf:${sel.workflow.workflow_id}`;
-      url = `/api/workflows/${encodeURIComponent(sel.workflow.workflow_id)}/result`;
+      // Relative (no leading slash) so it resolves against wherever the
+      // console is mounted — root or behind a reverse-proxy prefix.
+      url = `api/workflows/${encodeURIComponent(sel.workflow.workflow_id)}/result`;
       hasAny = sel.workflow.has_output || sel.workflow.has_error;
     } else {
       key = `step:${sel.step.workflow_id}:${sel.step.function_id}`;
       url =
-        `/api/workflows/${encodeURIComponent(sel.step.workflow_id)}` +
+        `api/workflows/${encodeURIComponent(sel.step.workflow_id)}` +
         `/steps/${sel.step.function_id}/result`;
       hasAny = sel.step.has_output || sel.step.has_error;
     }
@@ -301,10 +310,10 @@
       cur = cur.parent_workflow_id ? byId.get(cur.parent_workflow_id) : undefined;
     }
     breadcrumb.items = [
-      { label: "Workflows", href: "/workflows/", icon: "workflow", tooltip: "Workflows" },
+      { label: "Workflows", href: "#/workflows/", icon: "workflow", tooltip: "Workflows" },
       ...chain.map((w) => ({
         label: w.name ?? w.workflow_id,
-        href: `/workflows/${encodeURIComponent(w.workflow_id)}/`,
+        href: `#/workflows/${encodeURIComponent(w.workflow_id)}/`,
         status: w.status,
         tooltip: w.workflow_id,
       })),

--- a/apps/console/src/routes/workflows/[id]/+page.svelte
+++ b/apps/console/src/routes/workflows/[id]/+page.svelte
@@ -16,6 +16,7 @@
   import * as ToggleGroup from "$lib/components/ui/toggle-group";
   import { breadcrumb } from "$lib/breadcrumb.svelte";
   import { realtimeClient, type SubscriptionHandle } from "$lib/realtime";
+  import { routeUrl } from "$lib/route-url";
 
   type WorkflowDetail = {
     workflow_id: string;
@@ -80,7 +81,7 @@
   type DetailView = "graph" | "timeline";
   const VIEW_KEY = "argus.workflowDetail.view";
   function loadView(): DetailView {
-    const q = page.url.searchParams.get("view");
+    const q = routeUrl(page.url).searchParams.get("view");
     if (q === "graph" || q === "timeline") return q;
     try {
       if (typeof localStorage !== "undefined" && localStorage.getItem(VIEW_KEY) === "timeline")
@@ -98,15 +99,13 @@
     } catch {
       // Drop the write rather than crashing the handler.
     }
-    // Under hash routing the route and its query live in the URL fragment.
-    // page.url is the *decoded* form (route as pathname) — handing it to
-    // replaceState would rewrite the address bar to the path form, dropping
-    // the hash and any reverse-proxy mount prefix. Rewrite the query inside
-    // the fragment of the real browser URL instead.
-    const route = new URL(page.url.href);
+    // Under hash routing the route and its query live in the URL fragment —
+    // rewrite the query inside the fragment, keeping the browser URL's
+    // pathname (the mount point, e.g. a reverse-proxy prefix) untouched.
+    const route = routeUrl(page.url);
     if (v === "graph") route.searchParams.delete("view");
     else route.searchParams.set("view", v);
-    const url = new URL(window.location.href);
+    const url = new URL(page.url.href);
     url.hash = `#${route.pathname}${route.search}`;
     replaceState(url, {});
   }

--- a/apps/console/svelte.config.js
+++ b/apps/console/svelte.config.js
@@ -8,10 +8,21 @@ const config = {
     adapter: adapter({
       pages: "build",
       assets: "build",
-      fallback: "index.html",
+      // With hash routing the shell is prerendered to index.html with
+      // *relative* asset paths — that is what makes the bundle work behind a
+      // reverse-proxy prefix. Naming the fallback anything else keeps the
+      // adapter from overwriting it with the absolute-path fallback page
+      // (the server's own catch-all serves index.html for unknown paths).
+      fallback: "404.html",
       precompress: false,
       strict: true,
     }),
+    // Hash routing makes the built console mount-point agnostic: assets are
+    // referenced relatively and routes live in the fragment, so the same
+    // bundle works served at / or behind a reverse-proxy prefix (e.g. /argus)
+    // with no build-time base path. API/WS calls are relative for the same
+    // reason. Internal links must use the "#/..." form.
+    router: { type: "hash" },
   },
 };
 


### PR DESCRIPTION
Makes the built console mount-point agnostic: one image works at `/` or behind any stripped reverse-proxy prefix (e.g. `/argus/`) with zero configuration.

- **Hash routing** (`router.type: 'hash'`): routes live in the fragment, so the document URL is always the mount root. Internal links and `goto()` use the `#/...` form; the now-ignored page options in `+layout.ts` are removed.
- **Relative API/WS URLs**: `fetch` calls and the realtime socket resolve against the document base instead of hardcoding the origin root.
- **Shell build**: the adapter fallback moves to `404.html` so the prerendered `index.html` (what the server's SPA catch-all serves) keeps its runtime-computed base; a post-build step rewrites its entry imports, preloads, and favicons to relative URLs.
- **`routeUrl()` helper**: under the hash router `page.url` is the raw browser URL, so nav highlighting, the workflows `queue_name` scope, and the detail `view` param now decode the route from the fragment; the view toggle rewrites its query inside the fragment.
- **Legacy deep links**: path-style bookmarks (`/workflows/<id>`) redirect to the hash form via a shim in `app.html`, preserving any mount prefix.

README documents the proxy setup; changelog updated. Verified live at `/` and proxied under `/dbos/` with a stripped prefix: dashboard data, WS live updates, workflow list/detail, lazy result fetch, queue scoping, nav highlighting, and the Graph/Timeline toggle (including `?view=` deep links inside the fragment).